### PR TITLE
extract-stream: use file mapping on Windows

### DIFF
--- a/lib/extract-stream.js
+++ b/lib/extract-stream.js
@@ -3,6 +3,8 @@
 const Minipass = require('minipass')
 const path = require('path')
 const tar = require('tar')
+const fs = require('fs')
+const { O_CREAT, O_TRUNC, O_WRONLY, UV_FS_O_FILEMAP } = fs.constants
 
 module.exports = extractStream
 module.exports._computeMode = computeMode
@@ -49,6 +51,9 @@ function pkgJsonTransform (spec, opts) {
 
 function extractStream (spec, dest, opts) {
   opts = opts || {}
+  // Use a memory file mapping to write files if supported by Node.js
+  const fflag = (process.platform === 'win32' && UV_FS_O_FILEMAP)
+    ? (UV_FS_O_FILEMAP | O_TRUNC | O_CREAT | O_WRONLY) : 'w'
   const sawIgnores = new Set()
   return tar.x({
     cwd: dest,
@@ -57,6 +62,7 @@ function extractStream (spec, dest, opts) {
     onwarn: msg => opts.log && opts.log.warn('tar', msg),
     uid: opts.uid,
     gid: opts.gid,
+    fflag: fflag,
     umask: opts.umask,
     transform: opts.resolved && pkgJsonTransform(spec, opts),
     onentry (entry) {


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

This makes pacote take advantage of writing files using a file mapping on Windows when available, which can be significantly faster. Support landed in libuv in https://github.com/libuv/libuv/pull/2295 and in Node.js in https://github.com/nodejs/node/pull/29260. This PR has no effect unless a node-tar includes https://github.com/npm/node-tar/pull/227.

Using a file mapping is only an advantage in some situations which are hard to determine and vary widely from machine to machine. However, it is always better or similar when making a short number of writes to a file and the file is not too large (less than about 1MB). Extracting npm packages matches these conditions, and using a file mapping here seems to always be an advantage. On my tests, running npm with this change is often faster, up to almost half the time in some cases.

This PR does not include a test because the feature is always enabled and there is no API to know if a write operation was actually performed using a file mapping.