### PR TITLE
Return the requested spec as the 'from' value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ pacote.manifest('foo@1.x').then(manifest => console.log('got it', manifest))
 
 // extract a package into a folder
 pacote.extract('github:npm/cli', 'some/path', options)
-  .then(({resolved, integrity}) => {
-    console.log('extracted!', resolved, integrity)
+  .then(({from, resolved, integrity}) => {
+    console.log('extracted!', from, resolved, integrity)
   })
 
 pacote.tarball('https://server.com/package.tgz').then(data => {
@@ -31,12 +31,13 @@ This module exports a command line interface that can do most of what is
 described below.  Run `pacote -h` to learn more.
 
 ```
-Pacote - The JavaScript Package Handler, v10.0.0
+Pacote - The JavaScript Package Handler, v10.1.1
 
 Usage:
 
   pacote resolve <spec>
-    Fesolve a specifier and output the fully resolved target
+    Resolve a specifier and output the fully resolved target
+    Returns integrity and from if '--long' flag is set.
 
   pacote manifest <spec>
     Fetch a manifest and print to stdout
@@ -44,15 +45,20 @@ Usage:
   pacote packument <spec>
     Fetch a full packument and print to stdout
 
-  pacote tarball <spec> <filename>
+  pacote tarball <spec> [<filename>]
     Fetch a package tarball and save to <filename>
     If <filename> is missing or '-', the tarball will be streamed to stdout.
 
   pacote extract <spec> <folder>
     Extract a package to the destination folder.
 
-Configuration values all match the names of configs passed to npm, or options
-passed to Pacote.
+Configuration values all match the names of configs passed to npm, or
+options passed to Pacote.  Additional flags for this executable:
+
+  --long     Print an object from 'resolve', including integrity and spec.
+  --json     Print result objects as JSON rather than node's default.
+             (This is the default if stdout is not a TTY.)
+  --help -h  Print this helpful text.
 
 For example '--cache=/path/to/folder' will use that folder as the cache.
 ```
@@ -71,7 +77,7 @@ See below for valid `opts` values.
 
 * `pacote.extract(spec, dest, opts)` Extract a package's tarball into a
   destination folder.  Returns a promise that resolves to the
-  `{resolved,integrity}` of the extracted package.
+  `{from,resolved,integrity}` of the extracted package.
 
 * `pacote.manifest(spec, opts)` Fetch (or simulate) a package's manifest
   (basically, the `package.json` file, plus a bit of metadata).
@@ -85,11 +91,11 @@ See below for valid `opts` values.
 
 * `pacote.tarball(spec, opts)`  Get a package tarball data as a buffer in
   memory.  Returns a Promise that resolves to the tarball data Buffer, with
-  `resolved` and `integrity` fields attached.
+  `from`, `resolved`, and `integrity` fields attached.
 
 * `pacote.tarball.file(spec, dest, opts)`  Save a package tarball data to
   a file on disk.  Returns a Promise that resolves to
-  `{integrity,resolved}` of the fetched tarball.
+  `{from,integrity,resolved}` of the fetched tarball.
 
 * `pacote.tarball.stream(spec, streamHandler, opts)`  Fetch a tarball and
   make the stream available to the `streamHandler` function.
@@ -185,6 +191,7 @@ In addition to the common `package.json` fields, manifests include:
 
 * `manifest._resolved` The tarball url or file path where the package
   artifact can be found.
+* `manifest._from` A normalized form of the spec passed in as an argument.
 * `manifest._integrity` The integrity value for the package artifact.
 * `manifest.dist` Registry manifests (those included in a packument) have a
   `dist` object.  Only `tarball` is required, though at least one of

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -4,6 +4,12 @@ const run = conf => {
   const pacote = require('../')
   switch (conf._[0]) {
     case 'resolve':
+      if (conf.long)
+        return pacote.manifest(conf._[1], conf).then(mani => ({
+          resolved: mani._resolved,
+          integrity: mani._integrity,
+          from: mani._from,
+        }))
     case 'manifest':
     case 'packument':
       return pacote[conf._[0]](conf._[1], conf)
@@ -36,6 +42,7 @@ Usage:
 
   pacote resolve <spec>
     Resolve a specifier and output the fully resolved target
+    Returns integrity and from if '--long' flag is set.
 
   pacote manifest <spec>
     Fetch a manifest and print to stdout
@@ -50,8 +57,13 @@ Usage:
   pacote extract <spec> <folder>
     Extract a package to the destination folder.
 
-Configuration values all match the names of configs passed to npm, or options
-passed to Pacote.
+Configuration values all match the names of configs passed to npm, or
+options passed to Pacote.  Additional flags for this executable:
+
+  --long     Print an object from 'resolve', including integrity and spec.
+  --json     Print result objects as JSON rather than node's default.
+             (This is the default if stdout is not a TTY.)
+  --help -h  Print this helpful text.
 
 For example '--cache=/path/to/folder' will use that folder as the cache.
 `

--- a/lib/dir.js
+++ b/lib/dir.js
@@ -87,6 +87,7 @@ class DirFetcher extends Fetcher {
         ...mani,
         _integrity: String(this.integrity),
         _resolved: this.resolved,
+        _from: this.from,
       })
   }
 

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -45,6 +45,16 @@ class FetcherBase {
     if (!opts || typeof opts !== 'object')
       throw new TypeError('options object is required')
     this.spec = npa(spec, opts.where)
+
+    // a bit redundant because presumably the caller already knows this,
+    // but it makes it easier to not have to keep track of the requested
+    // spec when we're dispatching thousands of these at once, and normalizing
+    // is nice.  saveSpec is preferred if set, because it turns stuff like
+    // x/y#committish into github:x/y#committish.  use name@rawSpec for
+    // registry deps so that we turn xyz and xyz@ -> xyz@
+    this.from = this.spec.registry
+      ? `${this.spec.name}@${this.spec.rawSpec}` : this.spec.saveSpec
+
     this[_assertType]()
     this.opts = opts
     this.cache = opts.cache || cacheDir()
@@ -164,6 +174,7 @@ class FetcherBase {
         const data = Buffer.concat(buf)
         data.integrity = String(this.integrity)
         data.resolved = this.resolved
+        data.from = this.from
         return res(data)
       })
       stream.on('data', d => buf.push(d))
@@ -323,6 +334,7 @@ class FetcherBase {
       writer.on('close', () => res({
         integrity: this.integrity && String(this.integrity),
         resolved: this.resolved,
+        from: this.from,
       }))
       str.pipe(writer)
     }))
@@ -346,6 +358,7 @@ class FetcherBase {
         resolve({
           resolved: this.resolved,
           integrity: this.integrity && String(this.integrity),
+          from: this.from,
         })
       })
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -31,6 +31,7 @@ class FileFetcher extends Fetcher {
         ...mani,
         _integrity: String(this.integrity),
         _resolved: this.resolved,
+        _from: this.from,
       }))
   }
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -143,6 +143,7 @@ class GitFetcher extends Fetcher {
     const stream = new Minipass()
     stream.resolved = this.resolved
     stream.integrity = this.integrity
+    stream.from = this.from
 
     // check it out and then shell out to the DirFetcher tarball packer
     this[_clone](dir => this[_prepareDir](dir)

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -106,6 +106,7 @@ class RegistryFetcher extends Fetcher {
         const { dist } = mani
         if (dist) {
           this.resolved = mani._resolved = dist.tarball
+          mani._from = this.from
           if (!this.integrity) {
             if (dist.integrity)
               this.integrity = ssri.parse(dist.integrity)

--- a/tap-snapshots/test-bin.js-TAP.test.js
+++ b/tap-snapshots/test-bin.js-TAP.test.js
@@ -11,7 +11,7 @@ Object {
   "exitlog": Array [],
   "loglog": Array [
     Array [
-      "Pacote - The JavaScript Package Handler, v{VERSION}\\n\\nUsage:\\n\\n  pacote resolve <spec>\\n    Resolve a specifier and output the fully resolved target\\n\\n  pacote manifest <spec>\\n    Fetch a manifest and print to stdout\\n\\n  pacote packument <spec>\\n    Fetch a full packument and print to stdout\\n\\n  pacote tarball <spec> [<filename>]\\n    Fetch a package tarball and save to <filename>\\n    If <filename> is missing or '-', the tarball will be streamed to stdout.\\n\\n  pacote extract <spec> <folder>\\n    Extract a package to the destination folder.\\n\\nConfiguration values all match the names of configs passed to npm, or options\\npassed to Pacote.\\n\\nFor example '--cache=/path/to/folder' will use that folder as the cache.\\n",
+      "Pacote - The JavaScript Package Handler, v{VERSION}\\n\\nUsage:\\n\\n  pacote resolve <spec>\\n    Resolve a specifier and output the fully resolved target\\n    Returns integrity and from if '--long' flag is set.\\n\\n  pacote manifest <spec>\\n    Fetch a manifest and print to stdout\\n\\n  pacote packument <spec>\\n    Fetch a full packument and print to stdout\\n\\n  pacote tarball <spec> [<filename>]\\n    Fetch a package tarball and save to <filename>\\n    If <filename> is missing or '-', the tarball will be streamed to stdout.\\n\\n  pacote extract <spec> <folder>\\n    Extract a package to the destination folder.\\n\\nConfiguration values all match the names of configs passed to npm, or\\noptions passed to Pacote.  Additional flags for this executable:\\n\\n  --long     Print an object from 'resolve', including integrity and spec.\\n  --json     Print result objects as JSON rather than node's default.\\n             (This is the default if stdout is not a TTY.)\\n  --help -h  Print this helpful text.\\n\\nFor example '--cache=/path/to/folder' will use that folder as the cache.\\n",
     ],
   ],
 }
@@ -24,7 +24,7 @@ Object {
       "bad command: blerg",
     ],
     Array [
-      "Pacote - The JavaScript Package Handler, v{VERSION}\\n\\nUsage:\\n\\n  pacote resolve <spec>\\n    Resolve a specifier and output the fully resolved target\\n\\n  pacote manifest <spec>\\n    Fetch a manifest and print to stdout\\n\\n  pacote packument <spec>\\n    Fetch a full packument and print to stdout\\n\\n  pacote tarball <spec> [<filename>]\\n    Fetch a package tarball and save to <filename>\\n    If <filename> is missing or '-', the tarball will be streamed to stdout.\\n\\n  pacote extract <spec> <folder>\\n    Extract a package to the destination folder.\\n\\nConfiguration values all match the names of configs passed to npm, or options\\npassed to Pacote.\\n\\nFor example '--cache=/path/to/folder' will use that folder as the cache.\\n",
+      "Pacote - The JavaScript Package Handler, v{VERSION}\\n\\nUsage:\\n\\n  pacote resolve <spec>\\n    Resolve a specifier and output the fully resolved target\\n    Returns integrity and from if '--long' flag is set.\\n\\n  pacote manifest <spec>\\n    Fetch a manifest and print to stdout\\n\\n  pacote packument <spec>\\n    Fetch a full packument and print to stdout\\n\\n  pacote tarball <spec> [<filename>]\\n    Fetch a package tarball and save to <filename>\\n    If <filename> is missing or '-', the tarball will be streamed to stdout.\\n\\n  pacote extract <spec> <folder>\\n    Extract a package to the destination folder.\\n\\nConfiguration values all match the names of configs passed to npm, or\\noptions passed to Pacote.  Additional flags for this executable:\\n\\n  --long     Print an object from 'resolve', including integrity and spec.\\n  --json     Print result objects as JSON rather than node's default.\\n             (This is the default if stdout is not a TTY.)\\n  --help -h  Print this helpful text.\\n\\nFor example '--cache=/path/to/folder' will use that folder as the cache.\\n",
     ],
   ],
   "exitlog": Array [],
@@ -75,7 +75,7 @@ Object {
   "exitlog": Array [],
   "loglog": Array [
     Array [
-      "{\\n  \\"method\\": \\"manifest\\",\\n  \\"spec\\": \\"bar@foo\\",\\n  \\"conf\\": {\\n    \\"_\\": [\\n      \\"manifest\\",\\n      \\"bar@foo\\"\\n    ],\\n    \\"json\\": true,\\n    \\"cache\\": \\"{HOME}/.npm/_cacache\\"\\n  }\\n}",
+      "{\\n  \\"method\\": \\"manifest\\",\\n  \\"spec\\": \\"bar@foo\\",\\n  \\"conf\\": {\\n    \\"_\\": [\\n      \\"manifest\\",\\n      \\"bar@foo\\"\\n    ],\\n    \\"json\\": true,\\n    \\"cache\\": \\"{HOME}/.npm/_cacache\\"\\n  },\\n  \\"_resolved\\": \\"manifest resolved\\",\\n  \\"_integrity\\": \\"manifest integrity\\",\\n  \\"_from\\": \\"manifest from\\"\\n}",
     ],
   ],
 }
@@ -104,6 +104,18 @@ Object {
     1,
   ],
   "loglog": Array [],
+}
+`
+
+exports[`test/bin.js TAP main resolve foo@bar --long > must match snapshot 1`] = `
+Object {
+  "errorlog": Array [],
+  "exitlog": Array [],
+  "loglog": Array [
+    Array [
+      "{\\n  \\"resolved\\": \\"manifest resolved\\",\\n  \\"integrity\\": \\"manifest integrity\\",\\n  \\"from\\": \\"manifest from\\"\\n}",
+    ],
+  ],
 }
 `
 
@@ -147,6 +159,9 @@ Object {
 
 exports[`test/bin.js TAP run > expect resolving Promise 2`] = `
 Object {
+  "_from": "manifest from",
+  "_integrity": "manifest integrity",
+  "_resolved": "manifest resolved",
   "conf": Object {
     "_": Array [
       "manifest",
@@ -216,6 +231,7 @@ Usage:
 
   pacote resolve <spec>
     Resolve a specifier and output the fully resolved target
+    Returns integrity and from if '--long' flag is set.
 
   pacote manifest <spec>
     Fetch a manifest and print to stdout
@@ -230,8 +246,13 @@ Usage:
   pacote extract <spec> <folder>
     Extract a package to the destination folder.
 
-Configuration values all match the names of configs passed to npm, or options
-passed to Pacote.
+Configuration values all match the names of configs passed to npm, or
+options passed to Pacote.  Additional flags for this executable:
+
+  --long     Print an object from 'resolve', including integrity and spec.
+  --json     Print result objects as JSON rather than node's default.
+             (This is the default if stdout is not a TTY.)
+  --help -h  Print this helpful text.
 
 For example '--cache=/path/to/folder' will use that folder as the cache.
 

--- a/tap-snapshots/test-dir.js-TAP.test.js
+++ b/tap-snapshots/test-dir.js-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/dir.js TAP basic > extract 1`] = `
 Object {
+  "from": "file:test/fixtures/abbrev",
   "integrity": "sha512-Ict4yhLfiPOkcX+yjBRSI2QUetKt+A08AXMyLeQbKGYg/OGI/1k47Hu9tWZOx1l4j+M1z07Zxt3IL41TmLkbDw==",
   "resolved": "\${CWD}/test/fixtures/abbrev",
 }
@@ -14,6 +15,7 @@ Object {
 
 exports[`test/dir.js TAP basic > manifest 1`] = `
 Object {
+  "_from": "file:test/fixtures/abbrev",
   "_id": "abbrev@1.1.1",
   "_integrity": "null",
   "_resolved": "\${CWD}/test/fixtures/abbrev",
@@ -83,6 +85,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
+      "_from": "file:test/fixtures/abbrev",
       "_id": "abbrev@1.1.1",
       "_integrity": "null",
       "_resolved": "\${CWD}/test/fixtures/abbrev",
@@ -128,6 +131,7 @@ Object {
 
 exports[`test/dir.js TAP basic > saved package.json 1`] = `
 Object {
+  "_from": "file:test/fixtures/abbrev",
   "_id": "abbrev@1.1.1",
   "_integrity": "null",
   "_resolved": "\${CWD}/test/fixtures/abbrev",
@@ -167,6 +171,7 @@ Object {
 
 exports[`test/dir.js TAP make bins executable > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-object",
   "integrity": "sha512-rlE32nBV7XgKCm0I7YqAewyVPbaRJWUQMZUFLlngGK3imG+som3Hin7d/zPTikWg64tHIxb8VXeeq6u0IRRfmQ==",
   "resolved": "\${CWD}/test/fixtures/bin-object",
 }
@@ -174,6 +179,7 @@ Object {
 
 exports[`test/dir.js TAP with prepare script > extract 1`] = `
 Object {
+  "from": "file:test/fixtures/prepare-script",
   "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
@@ -189,6 +195,7 @@ Array [
 
 exports[`test/dir.js TAP with prepare script > manifest 1`] = `
 Object {
+  "_from": "file:test/fixtures/prepare-script",
   "_id": "git-prepare-script@1.0.0",
   "_integrity": "null",
   "_resolved": "\${CWD}/test/fixtures/prepare-script",
@@ -214,6 +221,7 @@ Object {
   "name": "git-prepare-script",
   "versions": Object {
     "1.0.0": Object {
+      "_from": "file:test/fixtures/prepare-script",
       "_id": "git-prepare-script@1.0.0",
       "_integrity": "null",
       "_resolved": "\${CWD}/test/fixtures/prepare-script",

--- a/tap-snapshots/test-fetcher.js-TAP.test.js
+++ b/tap-snapshots/test-fetcher.js-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/fetcher.js TAP make bins executable > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-object.tgz",
   "integrity": "sha512-TqzCjecWyQe8vqLbT0nv/OaWf0ptRZ2DnPmiuGUYJJb70shp02+/uu37IJSkM2ZEP1SAOeKrYrWPVIIYW+d//g==",
   "resolved": "{CWD}/test/fixtures/bin-object.tgz",
 }

--- a/tap-snapshots/test-fetcher.js-fake-sudo-TAP.test.js
+++ b/tap-snapshots/test-fetcher.js-fake-sudo-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/fetcher.js fake-sudo TAP make bins executable > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-object.tgz",
   "integrity": "sha512-TqzCjecWyQe8vqLbT0nv/OaWf0ptRZ2DnPmiuGUYJJb70shp02+/uu37IJSkM2ZEP1SAOeKrYrWPVIIYW+d//g==",
   "resolved": "{CWD}/test/fixtures/bin-object.tgz",
 }

--- a/tap-snapshots/test-file.js-TAP.test.js
+++ b/tap-snapshots/test-file.js-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/file.js TAP basic > extract 1`] = `
 Object {
+  "from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
 }
@@ -14,6 +15,7 @@ Object {
 
 exports[`test/file.js TAP basic > manifest 1`] = `
 Object {
+  "_from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "_id": "abbrev@1.1.1",
   "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "_resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
@@ -83,6 +85,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
+      "_from": "file:test/fixtures/abbrev-1.1.1.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
@@ -128,6 +131,7 @@ Object {
 
 exports[`test/file.js TAP make bins executable bin-good > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-good.tgz",
   "integrity": "sha512-Fx11OiHxV82CztnPk+k0S6H/66J4/eUzZEMGX2dJjP+Mxfrm8fSzE4SQG604zWk17ELZsOGENCdWSkvj4cpjUw==",
   "resolved": "\${CWD}/test/fixtures/bin-good.tgz",
 }
@@ -135,6 +139,7 @@ Object {
 
 exports[`test/file.js TAP make bins executable bin-object > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-object.tgz",
   "integrity": "sha512-TqzCjecWyQe8vqLbT0nv/OaWf0ptRZ2DnPmiuGUYJJb70shp02+/uu37IJSkM2ZEP1SAOeKrYrWPVIIYW+d//g==",
   "resolved": "\${CWD}/test/fixtures/bin-object.tgz",
 }
@@ -142,6 +147,7 @@ Object {
 
 exports[`test/file.js TAP make bins executable bin-string > results of unpack 1`] = `
 Object {
+  "from": "file:test/fixtures/bin-string.tgz",
   "integrity": "sha512-iCc87DMYVMofO221ksAlMD88Zgsr4OIvqeX73KxTPikWaQPvBFZpzI9FGWnD4PTLTyJzOSETQh86+IwEidJRZg==",
   "resolved": "\${CWD}/test/fixtures/bin-string.tgz",
 }

--- a/tap-snapshots/test-index.js-TAP.test.js
+++ b/tap-snapshots/test-index.js-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/index.js TAP > extract 1`] = `
 Object {
+  "from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
 }
@@ -14,6 +15,7 @@ Object {
 
 exports[`test/index.js TAP > manifest 1`] = `
 Object {
+  "_from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "_id": "abbrev@1.1.1",
   "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "_resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
@@ -53,6 +55,7 @@ Object {
 
 exports[`test/index.js TAP > manifest 2`] = `
 Object {
+  "_from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "_id": "abbrev@1.1.1",
   "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "_resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
@@ -98,6 +101,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
+      "_from": "file:test/fixtures/abbrev-1.1.1.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
@@ -147,6 +151,7 @@ exports[`test/index.js TAP > resolve 1`] = `
 
 exports[`test/index.js TAP > tarball to file 1`] = `
 Object {
+  "from": "file:test/fixtures/abbrev-1.1.1.tgz",
   "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
   "resolved": "\${CWD}/test/fixtures/abbrev-1.1.1.tgz",
 }

--- a/tap-snapshots/test-remote.js-TAP.test.js
+++ b/tap-snapshots/test-remote.js-TAP.test.js
@@ -13,6 +13,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
+      "_from": "http://localhost:{PORT}/abbrev.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "http://localhost:{PORT}/abbrev.tgz",
@@ -64,6 +65,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
+      "_from": "http://localhost:{PORT}/abbrev.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "http://localhost:{PORT}/abbrev.tgz",

--- a/test/bin.js
+++ b/test/bin.js
@@ -12,7 +12,14 @@ const called = []
 pacote.resolve = (spec, conf) =>
   spec === 'fail' ? Promise.reject(new Error('fail'))
   : Promise.resolve({method: 'resolve', spec, conf})
-pacote.manifest = (spec, conf) => Promise.resolve({method: 'manifest', spec, conf})
+pacote.manifest = (spec, conf) => Promise.resolve({
+  method: 'manifest',
+  spec,
+  conf,
+  _resolved: 'manifest resolved',
+  _integrity: 'manifest integrity',
+  _from: 'manifest from',
+})
 pacote.packument = (spec, conf) => Promise.resolve({method: 'packument', spec, conf})
 pacote.tarball.file = (spec, file, conf) => Promise.resolve({method: 'tarball', spec, file, conf})
 const Minipass = require('minipass')
@@ -103,6 +110,7 @@ t.test('main', t => {
 
   test('--help')
   test('resolve', 'foo@bar')
+  test('resolve', 'foo@bar', '--long')
   test('manifest', 'bar@foo')
   test('packument', 'paku@mint')
   test('tarball', 'tar@ball', 'file.tgz')

--- a/test/git.js
+++ b/test/git.js
@@ -254,7 +254,8 @@ t.test('basic stuff', async t => {
 
   const gx = await g.extract(me + '/g')
   const rx = await r.extract(me + '/r')
-  t.same(gx, rx, 'got the same resolved and integrity')
+  t.equal(gx.resolved, rx.resolved, 'got the same resolved')
+  t.equal(gx.integrity, rx.integrity, 'got the same integrity')
 
   // prepare script ran, files were filtered properly
   fs.statSync(me + '/g/index.js')

--- a/test/registry.js
+++ b/test/registry.js
@@ -68,6 +68,7 @@ t.test('underscore, no tag or version', t => {
   .then(result => t.deepEqual(result, {
     resolved: `${registry}underscore/-/underscore-1.5.1.tgz`,
     integrity: 'sha1-0r3oF9F2/63olKtxRY5oKhS4bck= sha512-yOc7VukmA45a1D6clUn1mD7Mbc9LcVYAQEXNKSTblzha59hSFJ6cAt90JDoxh05GQnTPI9nk4wjT/I8C/nAMPw==',
+    from: "underscore@",
   }))
 })
 
@@ -80,6 +81,7 @@ t.test('scoped, no tag or version', t => {
   .then(result => t.deepEqual(result, {
     resolved: `${registry}@isaacs/namespace-test/-/namespace-test-1.0.0.tgz`,
     integrity: 'sha512-5ZYe1LgwHIaag0p9loMwsf5N/wJ4XAuHVNhSO+qulQOXWnyJVuco6IZjo+5u4ZLF/GimdHJcX+QK892ONfOCqQ==',
+    from: "@isaacs/namespace-test@",
   }))
 })
 
@@ -121,6 +123,7 @@ t.test('a manifest that lacks integrity', t => {
     return f.extract(me + '/no-integrity')
   }).then(result => t.deepEqual(result, {
     resolved: `${registry}no-integrity/-/no-integrity-1.2.3.tgz`,
-    integrity: 'sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=='
+    integrity: 'sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==',
+    from: "no-integrity@",
   }, 'calculated integrity anyway'))
 })


### PR DESCRIPTION
While this is a bit redundant, given the fact that whoever is calling
pacote already knows this by definition, it's also a huge pain to track
when kicking off a ton of requests in parallel.  Much better to just
return it at the end of the process as well, to save the caller that
reassembly and bookkeeping.
