### PR TITLE
Exclude vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 !.gitattributes
 !map.js
 !index.js
+!*.swp
+!*.swo


### PR DESCRIPTION
A previous release shipped some Vim swap files. This should exclude them.
