### PR TITLE
Replace osenv with native node.js os module

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -13,7 +13,6 @@ const procLog = require('./util/proc-log.js')
 const retry = require('promise-retry')
 const fsm = require('fs-minipass')
 const cacache = require('cacache')
-const osenv = require('osenv')
 const isPackageBin = require('./util/is-package-bin.js')
 const getContents = require('@npmcli/installed-package-contents')
 

--- a/lib/util/cache-dir.js
+++ b/lib/util/cache-dir.js
@@ -1,10 +1,10 @@
-const osenv = require('osenv')
+const os = require('os')
 const {resolve} = require('path')
 
 module.exports = (fakePlatform = false) => {
-  const temp = osenv.tmpdir()
+  const temp = os.tmpdir()
   const uidOrPid = process.getuid ? process.getuid() : process.pid
-  const home = osenv.home() || resolve(temp, 'npm-' + uidOrPid)
+  const home = os.homedir() || resolve(temp, 'npm-' + uidOrPid)
   const platform = fakePlatform || process.platform
   const cacheExtra = platform === 'win32' ? 'npm-cache' : '.npm'
   const cacheRoot = (platform === 'win32' && process.env.APPDATA) || home

--- a/lib/util/git/env.js
+++ b/lib/util/git/env.js
@@ -1,6 +1,6 @@
 const uniqueFilename = require('unique-filename')
 const { join } = require('path')
-const osenv = require('osenv')
+const os = require('os')
 
 const goodEnvVars = new Set([
   'GIT_ASKPASS',
@@ -20,7 +20,7 @@ module.exports = () => {
     return gitEnv
 
   // we set the template dir to an empty folder to give git less to do
-  const tmpDir = join(osenv.tmpdir(), 'pacote-git-template-tmp')
+  const tmpDir = join(os.tmpdir(), 'pacote-git-template-tmp')
   const tmpName = uniqueFilename(tmpDir, 'git-clone')
   return gitEnv = Object.keys(process.env).reduce((gitEnv, k) => {
     if (goodEnvVars.has(k) || !k.startsWith('GIT_'))

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "npm-packlist": "^2.1.0",
     "npm-pick-manifest": "^6.0.0",
     "npm-registry-fetch": "^8.0.0",
-    "osenv": "^0.1.5",
     "promise-inflight": "^1.0.1",
     "promise-retry": "^1.1.1",
     "read-package-json-fast": "^1.1.3",

--- a/test/util/cache-dir.js
+++ b/test/util/cache-dir.js
@@ -1,8 +1,8 @@
 const t = require('tap')
-const osenv = require('osenv')
+const os = require('os')
 
-osenv.tmpdir = () => '/tmp'
-osenv.home = () => '/home/isaacs'
+os.tmpdir = () => '/tmp'
+os.homedir = () => '/home/isaacs'
 const path = require('path')
 path.resolve = path.posix.resolve
 process.getuid = () => 69420
@@ -21,7 +21,7 @@ t.ok(cacheDir(), 'a cache dir is ok')
 t.equal(cacheDir(posix), '/home/isaacs/.npm')
 t.equal(cacheDir(windows), '/home/isaacs/npm-cache')
 
-osenv.home = () => null
+os.homedir = () => null
 t.equal(cacheDir(posix), '/tmp/npm-69420/.npm')
 t.equal(cacheDir(windows), '/tmp/npm-69420/npm-cache')
 


### PR DESCRIPTION
# What / Why
Replace osenv with the native Node.js os module. Osenv seem to be used to add os path for old Node.js versions which are no longer maintained (If I understood correctly).

The module itself has not received any update since 16 Feb 2018.

Note: osenv remain in the tree because of npm-package-arg (i guess i will have to PR this package too if you'r ok with this).

![](https://i.imgur.com/4JQhRZL.png)

Best Regards,
Thomas