### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,22 +41,17 @@
     "chownr": "^1.1.4",
     "fs-minipass": "^2.1.0",
     "infer-owner": "^1.0.4",
-    "lru-cache": "^5.1.1",
     "minipass": "^3.0.1",
-    "minipass-fetch": "^1.2.1",
     "mkdirp": "^1.0.3",
     "npm-package-arg": "^8.0.1",
     "npm-packlist": "^2.1.0",
     "npm-pick-manifest": "^6.0.0",
     "npm-registry-fetch": "^8.0.0",
-    "promise-inflight": "^1.0.1",
     "promise-retry": "^1.1.1",
     "read-package-json-fast": "^1.1.3",
     "rimraf": "^2.7.1",
-    "semver": "^7.1.3",
     "ssri": "^8.0.0",
-    "tar": "^6.0.1",
-    "which": "^2.0.2"
+    "tar": "^6.0.1"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
# What / Why
Remove dependencies that are not directly used by pacote.

- lru-cache
- minipass-fetch
- promise-inflight
- semver
- which

They all stay in the three because they are all indirect dependencies.

Best Regards,
Thomas
