### PR TITLE
Consistently treat default registry as magic string

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -86,7 +86,8 @@ class FetcherBase {
     this.fullMetadata = this.before ? true : !!opts.fullMetadata
 
     this.defaultTag = opts.defaultTag || 'latest'
-    this.registry = opts.registry || 'https://registry.npmjs.org'
+    this.registry = (opts.registry || 'https://registry.npmjs.org')
+      .replace(/\/+$/, '')
 
     // command to run 'prepare' scripts on directories and git dirs
     // To use pacote with yarn, for example, set npmBin to 'yarn'

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -5,12 +5,17 @@ const pacoteVersion = require('../package.json').version
 const fetch = require('npm-registry-fetch')
 const ssri = require('ssri')
 const Minipass = require('minipass')
+// The default registry URL is a string of great magic.
+const magic = /^https?:\/\/registry\.npmjs\.org\//
 
 const _headers = Symbol('_headers')
 class RemoteFetcher extends Fetcher {
   constructor (spec, opts) {
     super(spec, opts)
     this.resolved = this.spec.fetchSpec
+    if (magic.test(this.resolved) && !magic.test(this.registry + '/'))
+      this.resolved = this.resolved.replace(magic, this.registry + '/')
+
     // nam is a fermented pork sausage that is good to eat
     const nameat = this.spec.name ? `${this.spec.name}@` : ''
     this.pkgid = opts.pkgid ? opts.pkgid : `remote:${nameat}${this.resolved}`

--- a/tap-snapshots/test-remote.js-TAP.test.js
+++ b/tap-snapshots/test-remote.js-TAP.test.js
@@ -13,7 +13,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
-      "_from": "http://localhost:{PORT}/abbrev.tgz",
+      "_from": "https://registry.npmjs.org/abbrev.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "http://localhost:{PORT}/abbrev.tgz",
@@ -53,7 +53,7 @@ Object {
   "name": "abbrev",
   "versions": Object {
     "1.1.1": Object {
-      "_from": "http://localhost:{PORT}/abbrev.tgz",
+      "_from": "https://registry.npmjs.org/abbrev.tgz",
       "_id": "abbrev@1.1.1",
       "_integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "_resolved": "http://localhost:{PORT}/abbrev.tgz",

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -435,7 +435,8 @@ if (!fakeSudo) {
 t.test('make bins executable', async t => {
   const file = resolve(__dirname, 'fixtures/bin-object.tgz')
   const spec = `file:${relative(process.cwd(), file)}`
-  const f = new FileFetcher(spec, {})
+  const f = new FileFetcher(spec, { registry: 'https://registry.npmjs.org///'})
+  t.equal(f.registry, 'https://registry.npmjs.org')
   // simulate a fetcher that already has a manifest
   const manifest = require('./fixtures/bin-object/package.json')
   f.package = manifest

--- a/test/remote.js
+++ b/test/remote.js
@@ -51,8 +51,9 @@ t.test('start server', t => {
 
 t.test('packument', t => {
   //const url = 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz'
-  const url = `${server}/abbrev.tgz`
+  const url = `https://registry.npmjs.org/abbrev.tgz`
   const f = new RemoteFetcher(url, {
+    registry: server,
     cache,
     preferOffline: true,
     headers: {
@@ -65,6 +66,7 @@ t.test('packument', t => {
   return t.resolveMatchSnapshot(f.packument(), 'packument')
     .then(() => {
       const f2 = new RemoteFetcher(`abbrev@${url}`, {
+        registry: server,
         pkgid: `remote:abbrev@${url}`,
         cache,
       })


### PR DESCRIPTION
There are a few places in npm where we treat the default registry url
https://registry.npmjs.org as a "Magic String", which always indicates
that the configured registry should be used.

This is important, because it means that lockfiles which are generated
while talking to one registry do not result in fetching from a different
registry to install their packages.  It also means that proxies which do
not rewrite the dist.tarball URLs will still effectively proxy, which is
often required in bastion-type networking setups.

NB: the *inverse* (ie, saving requests to alternative registries in
lockfiles and package.json files as https://registry.npmjs.org URLs) is
*not* done, as it could result in leaking the package names of private
code via requests to the main registry.

The missing piece in pacote was that it was not rewriting these urls in
the Remote fetcher, resulting in downloading packages from the public
registry even when a different registry is in use.

Note: this bug is why arborist's tests fail when networking is disabled.  Verified that the patch fixes the problem.