### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pacote
 
-JavaScript Package Handler
+Fetches package manifests and tarballs from the npm registry.
 
 ## USAGE
 
@@ -21,8 +21,9 @@ pacote.tarball('https://server.com/package.tgz').then(data => {
 })
 ```
 
-Anything that you can do to with kind of package, you can do to any kind of
-package.  Data that isn't relevant (like a packument for a tarball) will be
+`pacote` works with any kind of package specifier that npm can install. If you can pass it to the npm CLI, you can pass it to pacote. (In fact, that's exactly what the npm CLI does.)
+
+Data that isn't relevant (like a packument for a tarball) will be
 simulated.
 
 ## CLI


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> Clear up README text

The heading now states the purpose of `pacote` more clearly.

The text below the usage example was made to be grammatically correct and more understandable.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
