### PR TITLE
Don't fail when reading local sub-dependencies package.json

### DIFF
--- a/lib/fetchers/directory.js
+++ b/lib/fetchers/directory.js
@@ -37,8 +37,18 @@ Fetcher.impl(fetchDirectory, {
     const srPath = path.join(spec.fetchSpec, 'npm-shrinkwrap.json')
     return BB.join(
       readFileAsync(pkgPath).then(readJson).catch({ code: 'ENOENT' }, err => {
-        err.code = 'ENOPACKAGEJSON'
-        throw err
+        if (path.relative('', spec.fetchSpec).startsWith('..')) {
+          err.code = 'ENOPACKAGEJSON'
+          throw err
+        } else {
+          return {
+            name: spec.name,
+            _hasShrinkwrap: false,
+            _resolved: spec.fetchSpec,
+            _integrity: false, // Don't auto-calculate integrity
+            _shasum: false // Don't auto-calculate shasum either
+          }
+        }
       }),
       readFileAsync(srPath).then(readJson).catch({ code: 'ENOENT' }, () => null),
       (pkg, sr) => {


### PR DESCRIPTION
When trying to install sub-dependencies that are local dependencies (using the "file:..." pattern), Pacote always fail to read the `package.json` file because it don't yet exists.

The fix is kind of hacky, but I open the PR to start a discussion around this issue.


## References
Fixes #51 
