### PR TITLE
Prevent null TypeError using Pacote.tarball.file() as root on unix machines

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -290,7 +290,7 @@ class FetcherBase {
     return cacache.rm.content(this.cache, this.integrity, this.opts)
   }
 
-  [_chown] (path, uid, gid) {
+  async [_chown] (path, uid, gid) {
     return selfOwner && (selfOwner.gid !== gid || selfOwner.uid !== uid)
       ? chownr(path, uid, gid)
       : /* istanbul ignore next - we don't test in root-owned folders */ null


### PR DESCRIPTION
**What / Why**
I am getting this error on my Jenkins docker build:
```
TypeError: Cannot read property 'then' of null
  at /home/jenkins/agent/workspace/<project>/node_modules/pacote/lib/fetcher.js:355:13
```

This is because the return value of `this[_chown]` is `null`, and not a `Promise` as the `tarballFile()` logic assumes.
```javascript
  [_chown] (path, uid, gid) {
    return selfOwner && (selfOwner.gid !== gid || selfOwner.uid !== uid)
      ? chownr(path, uid, gid)
      : /* istanbul ignore next - we don't test in root-owned folders */ null
  }
```

This PR attempts to simply add a null check and otherwise maintain behavior. I've tested this issue with an internal build, and verified it resolves the issue. 