### PR TITLE
Add packumentCache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ resolved, and other properties, as they are determined.
   including information not strictly required for installation (author,
   description, etc.)  Defaults to `true` when `before` is set, since the
   version publish time is part of the extended packument metadata.
+* `packumentCache` For registry packuments only, you may provide a `Map`
+  object which will be used to cache packument requests between pacote
+  calls.  This allows you to easily avoid hitting the registry multiple
+  times (even just to validate the cache) for a given packument, since it
+  is unlikely to change in the span of a single command.
 
 ## Extracted File Modes
 

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -60,6 +60,7 @@ class FetcherBase {
     // clone the opts object so that others aren't upset when we mutate it
     // by adding/modifying the integrity value.
     this.opts = {...opts}
+
     this.cache = opts.cache || cacheDir()
     this.resolved = opts.resolved || null
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -20,6 +20,14 @@ class RegistryFetcher extends Fetcher {
   constructor (spec, opts) {
     super(spec, opts)
 
+    // you usually don't want to fetch the same packument multiple times in
+    // the span of a given script or command, no matter how many pacote calls
+    // are made, so this lets us avoid doing that.  It's only relevant for
+    // registry fetchers, because other types simulate their packument from
+    // the manifest, which they memoize on this.package, so it's very cheap
+    // already.
+    this.packumentCache = this.opts.packumentCache || null
+
     // handle case when npm-package-arg guesses wrong.
     if (this.spec.type === 'tag' &&
         this.spec.rawSpec === '' &&
@@ -64,11 +72,17 @@ class RegistryFetcher extends Fetcher {
     }
   }
 
-  packument () {
+  async packument () {
+    // note this might be either an in-flight promise for a request,
+    // or the actual packument, but we never want to make more than
+    // one request at a time for the same thing regardless.
+    if (this.packumentCache && this.packumentCache.has(this.packumentUrl))
+      return this.packumentCache.get(this.packumentUrl)
+
     // npm-registry-fetch the packument
     // set the appropriate header for corgis if fullMetadata isn't set
     // return the res.json() promise
-    return fetch(this.packumentUrl, {
+    const p = fetch(this.packumentUrl, {
       ...this.opts,
       headers: this[_headers](),
       spec: this.spec,
@@ -77,6 +91,8 @@ class RegistryFetcher extends Fetcher {
     }).then(res => res.json().then(packument => {
       packument._cached = res.headers.has('x-local-cache')
       packument._contentLength = +res.headers.get('content-length')
+      if (this.packumentCache)
+        this.packumentCache.set(this.pakumentUrl, packument)
       return packument
     })).catch(er => {
       if (er.code === 'E404' && !this.fullMetadata) {
@@ -86,6 +102,9 @@ class RegistryFetcher extends Fetcher {
       }
       throw er
     })
+    if (this.packumentCache)
+      this.packumentCache.set(this.packumentUrl, p)
+    return p
   }
 
   manifest () {


### PR DESCRIPTION
This allows us to avoid hitting the registry repeatedly to get the same
packument multiple times when we are resolving many different specifiers
for the same package name.

Even though these requests are cached after the first hit, just pinging
the registry with an ETag and getting a 304 response still adds up to
quite a bit of time waiting on network requests to complete.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
