### PR TITLE
Preserve git+https auth when provided

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -24,13 +24,16 @@ const _cloneRepo = Symbol('_cloneRepo')
 const _setResolvedWithSha = Symbol('_setResolvedWithSha')
 const _prepareDir = Symbol('_prepareDir')
 
-// get the repository url.  prefer ssh, fall back to git://
+// get the repository url.
+// prefer https if there's auth, since ssh will drop that.
+// otherwise, prefer ssh if available (more secure).
 // We have to add the git+ back because npa suppresses it.
-const repoUrl = (hosted, opts) =>
-  hosted.sshurl && addGitPlus(hosted.sshurl(opts)) ||
-  hosted.https && addGitPlus(hosted.https(opts))
+const repoUrl = (h, opts) =>
+  h.sshurl && !(h.https && h.auth) && addGitPlus(h.sshurl(opts)) ||
+  h.https && addGitPlus(h.https(opts))
 
-const addGitPlus = url => url && `git+${url}`
+// add git+ to the url, but only one time.
+const addGitPlus = url => url && `git+${url}`.replace(/^(git\+)+/, 'git+')
 
 class GitFetcher extends Fetcher {
   constructor (spec, opts) {
@@ -51,6 +54,11 @@ class GitFetcher extends Fetcher {
       this.resolvedSha = ''
   }
 
+  // just exposed to make it easier to test all the combinations
+  static repoUrl (hosted, opts) {
+    return repoUrl(hosted, opts)
+  }
+
   get types () {
     return ['git']
   }
@@ -69,13 +77,16 @@ class GitFetcher extends Fetcher {
   }
 
   // first try https, since that's faster and passphrase-less for
-  // public repos.  Fall back to SSH to support private repos.
-  // NB: we always store the SSH url in the 'resolved' field.
+  // public repos, and supports private repos when auth is provided.
+  // Fall back to SSH to support private repos
+  // NB: we always store the https url in resolved field if auth
+  // is present, otherwise ssh if the hosted type provides it
   [_resolvedFromHosted] (hosted) {
     return this[_resolvedFromRepo](hosted.https && hosted.https())
       .catch(er => {
         const ssh = hosted.sshurl && hosted.sshurl()
-        if (!ssh)
+        // no fallthrough if we can't fall through or have https auth
+        if (!ssh || hosted.auth)
           throw er
         return this[_resolvedFromRepo](ssh)
       })
@@ -121,9 +132,11 @@ class GitFetcher extends Fetcher {
   // either a git url with a hash, or a tarball download URL
   [_addGitSha] (sha) {
     if (this.spec.hosted) {
-      this[_setResolvedWithSha](
-        this.spec.hosted.shortcut({ noCommittish: true }) + '#' + sha
-      )
+      const h = this.spec.hosted
+      const opt = { noCommittish: true }
+      const base = h.https && h.auth ? h.https(opt) : h.shortcut(opt)
+
+      this[_setResolvedWithSha](`${base}#${sha}`)
     } else {
       const u = url.format(new url.URL(`#${sha}`, this.spec.rawSpec))
       this[_setResolvedWithSha](url.format(u))
@@ -232,14 +245,19 @@ class GitFetcher extends Fetcher {
     })
   }
 
+  // first try https, since that's faster and passphrase-less for
+  // public repos, and supports private repos when auth is provided.
+  // Fall back to SSH to support private repos
+  // NB: we always store the https url in resolved field if auth
+  // is present, otherwise ssh if the hosted type provides it
   [_cloneHosted] (ref, tmp) {
     const hosted = this.spec.hosted
     const https = hosted.https()
     return this[_cloneRepo](hosted.https({ noCommittish: true }), ref, tmp)
       .catch(er => {
         const ssh = hosted.sshurl && hosted.sshurl({ noCommittish: true })
-        /* istanbul ignore if - should be covered by the resolve() call */
-        if (!ssh)
+        // no fallthrough if we can't fall through or have https auth
+        if (!ssh || hosted.auth)
           throw er
         return this[_cloneRepo](ssh, ref, tmp)
       })


### PR DESCRIPTION
This makes pacote use the git+https: url as the resolved value for known
hosts when auth is provided.  When auth is not provided, we store the
ssh url as the resolved value, in order to maintain a canonical save
value that is never git:// for known hosts.

In order to fully fix npm/cli#2054, we will also need to have
@npmcli/arborist store the git+https url in the package-lock.json and
package.json if https auth is provided.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
