### PR TITLE
Use --force when installing deps for git prepare scripts

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -103,7 +103,7 @@ class FetcherBase {
     this.npmBin = opts.npmBin || 'npm'
 
     // command to install deps for preparing
-    this.npmInstallCmd = opts.npmInstallCmd || [ 'install' ]
+    this.npmInstallCmd = opts.npmInstallCmd || [ 'install', '--force' ]
 
     // XXX fill more of this in based on what we know from this.opts
     // we explicitly DO NOT fill in --tag, though, since we are often

--- a/tap-snapshots/test-fetcher.js-TAP.test.js
+++ b/tap-snapshots/test-fetcher.js-TAP.test.js
@@ -23,12 +23,14 @@ Array [
 exports[`test/fetcher.js TAP snapshot the npmInstallCmd and npmInstallConfig > default install cmd 1`] = `
 Array [
   "install",
+  "--force",
 ]
 `
 
 exports[`test/fetcher.js TAP snapshot the npmInstallCmd and npmInstallConfig > default install cmd with before 1`] = `
 Array [
   "install",
+  "--force",
 ]
 `
 

--- a/tap-snapshots/test-fetcher.js-fake-sudo-TAP.test.js
+++ b/tap-snapshots/test-fetcher.js-fake-sudo-TAP.test.js
@@ -23,12 +23,14 @@ Array [
 exports[`test/fetcher.js fake-sudo TAP snapshot the npmInstallCmd and npmInstallConfig > default install cmd 1`] = `
 Array [
   "install",
+  "--force",
 ]
 `
 
 exports[`test/fetcher.js fake-sudo TAP snapshot the npmInstallCmd and npmInstallConfig > default install cmd with before 1`] = `
 Array [
   "install",
+  "--force",
 ]
 `
 


### PR DESCRIPTION
If a git dependency has conflicting peerDependencies, dependencies with
engines fields that don't match the current environment, and so on, it
isn't much help to crash the installation for these issues.  The user
installing the git dependency is likely not in a position to fix them,
but from npm and Arborist's points of view, it is the 'main' project
that has a problem (since the install is being run as a separate
process).

This commit passes '--force' to the npm child process that installs
dependencies for git packages before running their 'prepare' script, to
ignore all such issues (or reduce them to warnings).

Related to: https://github.com/npm/cli/issues/2548

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
