### PR TITLE
Prevent infinite recursion in git dep preparation

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -110,7 +110,7 @@ class FetcherBase {
     // going to be packing in the context of a publish, which may set
     // a dist-tag, but certainly wants to keep defaulting to latest.
     this.npmCliConfig = opts.npmCliConfig || [
-      `--cache=${this.cache}`,
+      `--cache=${dirname(this.cache)}`,
       `--prefer-offline=${!!this.preferOffline}`,
       `--prefer-online=${!!this.preferOnline}`,
       `--offline=${!!this.offline}`,

--- a/lib/util/cache-dir.js
+++ b/lib/util/cache-dir.js
@@ -7,6 +7,6 @@ module.exports = (fakePlatform = false) => {
   const home = os.homedir() || resolve(temp, 'npm-' + uidOrPid)
   const platform = fakePlatform || process.platform
   const cacheExtra = platform === 'win32' ? 'npm-cache' : '.npm'
-  const cacheRoot = (platform === 'win32' && process.env.APPDATA) || home
-  return resolve(cacheRoot, cacheExtra)
+  const cacheRoot = (platform === 'win32' && process.env.LOCALAPPDATA) || home
+  return resolve(cacheRoot, cacheExtra, '_cacache')
 }

--- a/lib/util/npm.js
+++ b/lib/util/npm.js
@@ -1,9 +1,15 @@
 // run an npm command
 const spawn = require('@npmcli/promise-spawn')
+const {dirname} = require('path')
 
-module.exports = (npmBin, npmCommand, cwd, extra) => {
+module.exports = (npmBin, npmCommand, cwd, env, extra) => {
   const isJS = npmBin.endsWith('.js')
   const cmd = isJS ? process.execPath : npmBin
   const args = (isJS ? [npmBin] : []).concat(npmCommand)
-  return spawn(cmd, args, { cwd, stdioString: true }, extra)
+  // when installing to run the `prepare` script for a git dep, we need
+  // to ensure that we don't run into a cycle of checking out packages
+  // in temp directories.  this lets us link previously-seen repos that
+  // are also being prepared.
+
+  return spawn(cmd, args, { cwd, stdioString: true, env }, extra)
 }

--- a/tap-snapshots/test-util-npm.js-TAP.test.js
+++ b/tap-snapshots/test-util-npm.js-TAP.test.js
@@ -16,7 +16,7 @@ Object {
   "message": "oopsie",
   "signal": undefined,
   "stderr": "",
-  "stdout": "[\\"{NODE}\\",[\\"/path/to/npm/bin/npm-cli.js\\",\\"flerb\\"],{\\"cwd\\":\\"/cwd\\",\\"stdioString\\":true}]",
+  "stdout": "[\\"{NODE}\\",[\\"/path/to/npm/bin/npm-cli.js\\",\\"flerb\\"],{\\"cwd\\":\\"/cwd\\",\\"stdioString\\":true,\\"env\\":{\\"environmental\\":\\"variables\\"}}]",
 }
 `
 
@@ -30,6 +30,6 @@ Object {
   "message": "oopsie",
   "signal": undefined,
   "stderr": "",
-  "stdout": "[\\"/path/to/npm\\",[\\"flerb\\"],{\\"cwd\\":\\"/cwd\\",\\"stdioString\\":true}]",
+  "stdout": "[\\"/path/to/npm\\",[\\"flerb\\"],{\\"cwd\\":\\"/cwd\\",\\"stdioString\\":true,\\"env\\":{\\"environmental\\":\\"variables\\"}}]",
 }
 `

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -67,6 +67,10 @@ t.test('snapshot the npmInstallCmd and npmInstallConfig', async t => {
   t.equal(def.npmBin, 'npm', 'use default npm bin')
   t.matchSnapshot(def.npmInstallCmd, 'default install cmd')
   t.matchSnapshot(def.npmCliConfig, 'default install config')
+  t.notEqual(basename(def.npmCliConfig[0]), '_cacache',
+    'do not have a _cacache folder on cache config passed to npm cli')
+  t.equal(basename(def.cache), '_cacache',
+    'have a _cacache folder on default pacote config itself')
   const bef = new FileFetcher(abbrevspec, {
     before: new Date('1979-07-01T19:10:00.000Z'),
   })

--- a/test/util/cache-dir.js
+++ b/test/util/cache-dir.js
@@ -6,7 +6,7 @@ os.homedir = () => '/home/isaacs'
 const path = require('path')
 path.resolve = path.posix.resolve
 process.getuid = () => 69420
-process.env.APPDATA = ''
+process.env.LOCALAPPDATA = ''
 const isWindows = process.platform === 'win32'
 const posix = isWindows ? 'posix' : null
 const windows = isWindows ? null : 'win32'
@@ -18,15 +18,15 @@ const cacheDir = require('../../lib/util/cache-dir.js')
 // on all platforms.
 t.ok(cacheDir(), 'a cache dir is ok')
 
-t.equal(cacheDir(posix), '/home/isaacs/.npm')
-t.equal(cacheDir(windows), '/home/isaacs/npm-cache')
+t.equal(cacheDir(posix), '/home/isaacs/.npm/_cacache')
+t.equal(cacheDir(windows), '/home/isaacs/npm-cache/_cacache')
 
 os.homedir = () => null
-t.equal(cacheDir(posix), '/tmp/npm-69420/.npm')
-t.equal(cacheDir(windows), '/tmp/npm-69420/npm-cache')
+t.equal(cacheDir(posix), '/tmp/npm-69420/.npm/_cacache')
+t.equal(cacheDir(windows), '/tmp/npm-69420/npm-cache/_cacache')
 
-process.env.APPDATA = '/%APPDATA%'
-t.equal(cacheDir(windows), '/%APPDATA%/npm-cache')
+process.env.LOCALAPPDATA = '/%LOCALAPPDATA%'
+t.equal(cacheDir(windows), '/%LOCALAPPDATA%/npm-cache/_cacache')
 
 process.getuid = null
-t.equal(cacheDir(posix), `/tmp/npm-${process.pid}/.npm`)
+t.equal(cacheDir(posix), `/tmp/npm-${process.pid}/.npm/_cacache`)

--- a/test/util/npm.js
+++ b/test/util/npm.js
@@ -11,14 +11,14 @@ cp.spawn = (...args) => {
   proc.stdout.on('end', () => setTimeout(() => proc.emit('close')))
   return proc
 }
+t.teardown = () => cp.spawn = spawn
 
 t.cleanSnapshot = s => s.split(process.execPath).join('{NODE}')
 
 const npm = require('../../lib/util/npm.js')
 t.test('do the things', t => {
-  t.pass('wtf')
-  t.resolveMatchSnapshot(npm('/path/to/npm/bin/npm-cli.js', 'flerb', '/cwd', { message: 'oopsie' }))
-  t.resolveMatchSnapshot(npm('/path/to/npm', 'flerb', '/cwd', { message: 'oopsie' }))
+  const env = { environmental: 'variables' }
+  t.resolveMatchSnapshot(npm('/path/to/npm/bin/npm-cli.js', 'flerb', '/cwd', env, { message: 'oopsie' }))
+  t.resolveMatchSnapshot(npm('/path/to/npm', 'flerb', '/cwd', env, { message: 'oopsie' }))
   t.end()
 })
-cp.spawn = spawn


### PR DESCRIPTION
Prevent infinite recursion in git dep preparation

When a git spec is installed, we clone the repo and run 'npm install' if
it has a prepare script, so that the correct bits get loaded.

If one of its dependencies is also a git spec, we do the same thing for
that dependency.

If the dependency graph loops back on itself, we're in trouble.

The solution here is to track the path of git prepare steps we've
followed, and bail out of it when a cycle is detected.  This MAY result
in a package dependency not being fully built, and if that git dep's
preparation is required for the dependent to properly be installed, oh
well, that's going to break.

But what it WON'T do is create an infinitely deep tree of processes
calling npm and git recursively without end until the user SIGINTs out
of it.

See: https://twitter.com/addaleax/status/1347909082829750273

CC: @addaleax