### PR TITLE
Do not crash on scp-style URLs for unknown hosts

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -18,6 +18,7 @@ const _resolvedFromHosted = Symbol('_resolvedFromHosted')
 const _resolvedFromClone = Symbol('_resolvedFromClone')
 const _tarballFromResolved = Symbol.for('pacote.Fetcher._tarballFromResolved')
 const _addGitSha = Symbol('_addGitSha')
+const addGitSha = require('./util/add-git-sha.js')
 const _clone = Symbol('_clone')
 const _cloneHosted = Symbol('_cloneHosted')
 const _cloneRepo = Symbol('_cloneRepo')
@@ -131,16 +132,7 @@ class GitFetcher extends Fetcher {
   // when we get the git sha, we affix it to our spec to build up
   // either a git url with a hash, or a tarball download URL
   [_addGitSha] (sha) {
-    if (this.spec.hosted) {
-      const h = this.spec.hosted
-      const opt = { noCommittish: true }
-      const base = h.https && h.auth ? h.https(opt) : h.shortcut(opt)
-
-      this[_setResolvedWithSha](`${base}#${sha}`)
-    } else {
-      const u = url.format(new url.URL(`#${sha}`, this.spec.rawSpec))
-      this[_setResolvedWithSha](url.format(u))
-    }
+    this[_setResolvedWithSha](addGitSha(this.spec, sha))
   }
 
   [_resolvedFromClone] () {

--- a/lib/util/add-git-sha.js
+++ b/lib/util/add-git-sha.js
@@ -1,0 +1,15 @@
+// add a sha to a git remote url spec
+const addGitSha = (spec, sha) => {
+  if (spec.hosted) {
+    const h = spec.hosted
+    const opt = { noCommittish: true }
+    const base = h.https && h.auth ? h.https(opt) : h.shortcut(opt)
+
+    return `${base}#${sha}`
+  } else {
+    // don't use new URL for this, because it doesn't handle scp urls
+    return spec.rawSpec.replace(/#.*$/, '') + `#${sha}`
+  }
+}
+
+module.exports = addGitSha

--- a/test/util/add-git-sha.js
+++ b/test/util/add-git-sha.js
@@ -1,0 +1,36 @@
+const t = require('tap')
+const addGitSha = require('../../lib/util/add-git-sha.js')
+const npa = require('npm-package-arg')
+
+const cases = [
+  // unknown host
+  ['git+ssh://git@some-host:user/repo', 'sha', 'git+ssh://git@some-host:user/repo#sha'],
+  ['git+ssh://git@some-host:user/repo#othersha', 'sha', 'git+ssh://git@some-host:user/repo#sha'],
+  ['git+ssh://git@some-host:user/repo#othersha#otherothersha', 'sha', 'git+ssh://git@some-host:user/repo#sha'],
+  ['git+ssh://git@some-host/user/repo', 'sha', 'git+ssh://git@some-host/user/repo#sha'],
+  ['git+ssh://git@some-host/user/repo#othersha', 'sha', 'git+ssh://git@some-host/user/repo#sha'],
+  ['git+ssh://git@some-host/user/repo#othersha#otherothersha', 'sha', 'git+ssh://git@some-host/user/repo#sha'],
+  // github shorthand
+  ['github:user/repo', 'sha', 'github:user/repo#sha'],
+  ['github:user/repo#othersha', 'sha', 'github:user/repo#sha'],
+  ['github:user/repo#othersha#otherothersha', 'sha', 'github:user/repo#sha'],
+  // github https with auth
+  ['git+https://git@github.com/user/repo', 'sha', 'https://git@github.com/user/repo.git#sha'],
+  ['git+https://git@github.com/user/repo#othersha', 'sha', 'https://git@github.com/user/repo.git#sha'],
+  ['git+https://git@github.com/user/repo#othersha#otherothersha', 'sha', 'https://git@github.com/user/repo.git#sha'],
+  // github https no auth
+  ['git+https://github.com/user/repo', 'sha', 'github:user/repo#sha'],
+  ['git+https://github.com/user/repo#othersha', 'sha', 'github:user/repo#sha'],
+  ['git+https://github.com/user/repo#othersha#otherothersha', 'sha', 'github:user/repo#sha'],
+  // github ssh
+  ['git+ssh://git@github.com/user/repo', 'sha', 'github:user/repo#sha'],
+  ['git+ssh://git@github.com/user/repo#othersha', 'sha', 'github:user/repo#sha'],
+  ['git+ssh://git@github.com/user/repo#othersha#otherothersha', 'sha', 'github:user/repo#sha'],
+  ['git+ssh://git@github.com:user/repo', 'sha', 'github:user/repo#sha'],
+  ['git+ssh://git@github.com:user/repo#othersha', 'sha', 'github:user/repo#sha'],
+  ['git+ssh://git@github.com:user/repo#othersha#otherothersha', 'sha', 'github:user/repo#sha'],
+]
+
+t.plan(cases.length)
+for (const [spec, sha, result] of cases)
+  t.equal(addGitSha(npa(spec), sha), result, `${spec} + ${sha} = ${result}`)


### PR DESCRIPTION
We can't use `new URL()` to parse these, because they're not valid URLs.
But it turns out we don't have to actually parse the url just to swap
out the hash portion anyway.

Fix: #60

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
