### PR TITLE
feat: exposes tar create options

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ resolved, and other properties, as they are determined.
   times (even just to validate the cache) for a given packument, since it
   is unlikely to change in the span of a single command.
 
+
+### Advanced API
+
+Each different type of fetcher is exposed for more advanced usage such as
+using helper methods from this classes:
+
+* `DirFetcher`
+* `FileFetcher`
+* `GitFetcher`
+* `RegistryFetcher`
+* `RemoteFetcher`
+
 ## Extracted File Modes
 
 Files are extracted with a mode matching the following formula:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,16 @@
 const { get } = require('./fetcher.js')
+const GitFetcher = require('./git.js')
+const RegistryFetcher = require('./registry.js')
+const FileFetcher = require('./file.js')
+const DirFetcher = require('./dir.js')
+const RemoteFetcher = require('./remote.js')
+
 module.exports = {
+  GitFetcher,
+  RegistryFetcher,
+  FileFetcher,
+  DirFetcher,
+  RemoteFetcher,
   resolve: (spec, opts) => get(spec, opts).resolve(),
   extract: (spec, dest, opts) => get(spec, opts).extract(dest),
   manifest: (spec, opts) => get(spec, opts).manifest(),

--- a/lib/util/tar-create-options.js
+++ b/lib/util/tar-create-options.js
@@ -1,0 +1,24 @@
+const isPackageBin = require('./is-package-bin.js')
+
+const tarCreateOptions = manifest => ({
+  cwd: manifest._resolved,
+  prefix: 'package/',
+  portable: true,
+  gzip: true,
+
+  // ensure that package bins are always executable
+  // Note that npm-packlist is already filtering out
+  // anything that is not a regular file, ignored by
+  // .npmignore or package.json "files", etc.
+  filter: (path, stat) => {
+    if (isPackageBin(manifest, path))
+      stat.mode |= 0o111
+    return true
+  },
+
+  // Provide a specific date in the 1980s for the benefit of zip,
+  // which is confounded by files dated at the Unix epoch 0.
+  mtime: new Date('1985-10-26T08:15:00.000Z'),
+})
+
+module.exports = tarCreateOptions

--- a/test/dir.js
+++ b/test/dir.js
@@ -136,3 +136,18 @@ t.test('make bins executable', async t => {
   t.matchSnapshot(resTest, 'results of unpack')
   t.equal(fs.statSync(target + '/script.js').mode & 0o111, 0o111)
 })
+
+t.test('exposes tarCreateOptions method', async t => {
+  const simpleOpts = DirFetcher.tarCreateOptions({ _resolved: '/home/foo' })
+  t.match(
+    simpleOpts,
+    {
+      cwd: '/home/foo',
+      prefix: 'package/',
+      portable: true,
+      gzip: true,
+      mtime: new Date('1985-10-26T08:15:00.000Z'),
+    },
+    'should return standard options'
+  )
+})

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,12 @@ const t = require('tap')
 const pacote = require('../lib/index.js')
 const fs = require('fs')
 
+const GitFetcher = require('../lib/git.js')
+const RegistryFetcher = require('../lib/registry.js')
+const FileFetcher = require('../lib/file.js')
+const DirFetcher = require('../lib/dir.js')
+const RemoteFetcher = require('../lib/remote.js')
+
 const { resolve, relative } = require('path')
 const abbrev = resolve(__dirname, 'fixtures/abbrev-1.1.1.tgz')
 const abbrevspec = `file:${relative(process.cwd(), abbrev)}`
@@ -35,3 +41,9 @@ const stream = pacote.tarball.stream(abbrevspec, stream =>
     t.match(fs.readFileSync(me + '/stream.tgz'), fs.readFileSync(abbrev)))
 
 t.resolveMatchSnapshot(pacote.manifest(abbrevspec), 'manifest')
+
+t.equal(pacote.GitFetcher, GitFetcher, 'should expose fetcher classes')
+t.equal(pacote.RegistryFetcher, RegistryFetcher, 'should expose fetcher classes')
+t.equal(pacote.FileFetcher, FileFetcher, 'should expose fetcher classes')
+t.equal(pacote.DirFetcher, DirFetcher, 'should expose fetcher classes')
+t.equal(pacote.RemoteFetcher, RemoteFetcher, 'should expose fetcher classes')

--- a/test/util/tar-create-options.js
+++ b/test/util/tar-create-options.js
@@ -1,0 +1,27 @@
+const t = require('tap')
+const tarCreateOptions = require('../../lib/util/tar-create-options.js')
+
+const simpleOpts = tarCreateOptions({ _resolved: '/home/foo' })
+t.match(
+  simpleOpts,
+  {
+    cwd: '/home/foo',
+    prefix: 'package/',
+    portable: true,
+    gzip: true,
+    mtime: new Date('1985-10-26T08:15:00.000Z'),
+  },
+  'should return standard options'
+)
+
+t.ok(simpleOpts.filter('foo', {}), 'should not filter anything')
+
+const optsWithBins = tarCreateOptions({
+  bin: { a: 'index.js' },
+  _resolved: '/foo'
+})
+
+const stat = { mode: 0o644 }
+const filterRes = optsWithBins.filter('index.js', stat)
+t.equal(stat.mode, 0o755, 'should return an executable stat')
+t.equal(filterRes, true, 'should not filter out files')


### PR DESCRIPTION
Exposes `tar.c` options as a helper util. Useful for other apps that
might want to replicate the same tarball creation from the npm cli in
different contexts.

Related to: https://github.com/npm/libnpmdiff/pull/3

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
