### PR TITLE
fix: create consistent output across architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         # todo: add windows-latest to this list.
         # Right now, it's just too flaky and hard to get PWD and HOME out
         # of all the snapshots properly.
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,35 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
-      matrix:
-        node-version: [10.x, 12.x, 13.x]
-        # todo: add windows-latest to this list.
-        # Right now, it's just too flaky and hard to get PWD and HOME out
-        # of all the snapshots properly.
-        os: [ubuntu-latest, macOS-latest, windows-latest]
       fail-fast: false
+      matrix:
+        node-version: ['10.1', 10.x, '12.1', 12.x, '14.1', 14.x]
+        platform:
+          - os: ubuntu-latest
+            shell: bash
+          - os: macos-latest
+            shell: bash
+          - os: windows-latest
+            shell: bash
+          - os: windows-latest
+            shell: powershell
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v1.1.0
+        uses: actions/checkout@v2
 
       - name: Use Nodejs ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Update npm
+        run: npm install -g npm
 
       - name: Install dependencies
         run: npm install

--- a/lib/util/tar-create-options.js
+++ b/lib/util/tar-create-options.js
@@ -1,10 +1,16 @@
+const zlib = require('zlib')
 const isPackageBin = require('./is-package-bin.js')
 
 const tarCreateOptions = manifest => ({
   cwd: manifest._resolved,
   prefix: 'package/',
   portable: true,
-  gzip: true,
+  gzip: {
+    // forcing the compression strategy to Z_RLE
+    // yields a bit-identical, though considerably
+    // larger, end result in both arm64 and x86_64.
+    strategy: zlib.constants.Z_RLE
+  },
 
   // ensure that package bins are always executable
   // Note that npm-packlist is already filtering out

--- a/tap-snapshots/test-dir.js-TAP.test.js
+++ b/tap-snapshots/test-dir.js-TAP.test.js
@@ -8,7 +8,7 @@
 exports[`test/dir.js TAP basic > extract 1`] = `
 Object {
   "from": "file:test/fixtures/abbrev",
-  "integrity": "sha512-Ict4yhLfiPOkcX+yjBRSI2QUetKt+A08AXMyLeQbKGYg/OGI/1k47Hu9tWZOx1l4j+M1z07Zxt3IL41TmLkbDw==",
+  "integrity": "sha512-iCEu2GgFDiFk7K1qG3hdEsSf88hyxS1rFKtcc8N4aPZZFR5+IIUK5xsPkpLMHCdQttCN+eSP5qMS2ZW4XKMy2g==",
   "resolved": "\${CWD}/test/fixtures/abbrev",
 }
 `
@@ -176,7 +176,7 @@ Object {
 exports[`test/dir.js TAP make bins executable > results of unpack 1`] = `
 Object {
   "from": "file:test/fixtures/bin-object",
-  "integrity": "sha512-rlE32nBV7XgKCm0I7YqAewyVPbaRJWUQMZUFLlngGK3imG+som3Hin7d/zPTikWg64tHIxb8VXeeq6u0IRRfmQ==",
+  "integrity": "sha512-IKQYaxHY6sS/+fMP1EPUJF0+6a2Rk9Ek7QoJpY+h/NvNGHsMdVzhRFcRwUAuWt9196rWIY/pKi8aCw8jOwR4kg==",
   "resolved": "\${CWD}/test/fixtures/bin-object",
 }
 `
@@ -184,7 +184,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-WVTDu5aN+EdeoftNUCvhrDZUg+JVdIs2nkoskE8ijueo/w4Z0198tY5Ow0GFpzBhpf3PRsy67N2wvVzDRLDJNw==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -250,7 +250,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true and log:{level: silent} > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-WVTDu5aN+EdeoftNUCvhrDZUg+JVdIs2nkoskE8ijueo/w4Z0198tY5Ow0GFpzBhpf3PRsy67N2wvVzDRLDJNw==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -316,7 +316,7 @@ Object {
 exports[`test/dir.js TAP with prepare script > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-WVTDu5aN+EdeoftNUCvhrDZUg+JVdIs2nkoskE8ijueo/w4Z0198tY5Ow0GFpzBhpf3PRsy67N2wvVzDRLDJNw==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `

--- a/test/dir.js
+++ b/test/dir.js
@@ -145,7 +145,9 @@ t.test('exposes tarCreateOptions method', async t => {
       cwd: '/home/foo',
       prefix: 'package/',
       portable: true,
-      gzip: true,
+      gzip: {
+        strategy: 3
+      },
       mtime: new Date('1985-10-26T08:15:00.000Z'),
     },
     'should return standard options'

--- a/test/util/tar-create-options.js
+++ b/test/util/tar-create-options.js
@@ -8,7 +8,9 @@ t.match(
     cwd: '/home/foo',
     prefix: 'package/',
     portable: true,
-    gzip: true,
+    gzip: {
+      strategy: 3
+    },
     mtime: new Date('1985-10-26T08:15:00.000Z'),
   },
   'should return standard options'


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
thanks to architecture specific optimizations in the default deflate compression strategies, we end up with inconsistent output between arm64 and x86_64.

this change forces the compression strategy to one that appears to give more consistent results. they are larger, but since they're just temp files that feels like an acceptable trade off in the name of consistency.

for posterity's sake i'll mention here that Z_HUFFMAN_ONLY also provides a consistent end result, though i found better performance and compression with Z_RLE in some brief testing of a handful of npm related repositories.

note: i updated the CI matrix to match that of https://github.com/npm/cli

yes, the windows tests fail. however, i felt it was important to test the updated compression strategy for consistency in windows as well as linux and osx. i can fix the rest of the tests for windows before this lands, or we can land it as-is with a follow up PR to fix the tests for windows

edit: the node 10.1 test failures were a surprise, though appear to be unrelated to these changes

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes https://github.com/npm/cli/issues/2846