### PR TITLE
fix: force gzip compression level to 9

### DIFF
--- a/lib/util/tar-create-options.js
+++ b/lib/util/tar-create-options.js
@@ -4,7 +4,13 @@ const tarCreateOptions = manifest => ({
   cwd: manifest._resolved,
   prefix: 'package/',
   portable: true,
-  gzip: true,
+  gzip: {
+    // forcing the level to 9 seems to avoid some
+    // platform specific optimizations that cause
+    // integrity mismatch errors due to differing
+    // end results after compression
+    level: 9
+  },
 
   // ensure that package bins are always executable
   // Note that npm-packlist is already filtering out

--- a/tap-snapshots/test-dir.js-TAP.test.js
+++ b/tap-snapshots/test-dir.js-TAP.test.js
@@ -8,7 +8,7 @@
 exports[`test/dir.js TAP basic > extract 1`] = `
 Object {
   "from": "file:test/fixtures/abbrev",
-  "integrity": "sha512-Ict4yhLfiPOkcX+yjBRSI2QUetKt+A08AXMyLeQbKGYg/OGI/1k47Hu9tWZOx1l4j+M1z07Zxt3IL41TmLkbDw==",
+  "integrity": "sha512-OCm45DHz7n9f1SEllmg3Bf1zBCzsiOYxMuodMZ5ux+HMoupmkzOftyOCKH07DhAcoyfUlos2VGmYkPHDxH92yg==",
   "resolved": "\${CWD}/test/fixtures/abbrev",
 }
 `
@@ -176,7 +176,7 @@ Object {
 exports[`test/dir.js TAP make bins executable > results of unpack 1`] = `
 Object {
   "from": "file:test/fixtures/bin-object",
-  "integrity": "sha512-rlE32nBV7XgKCm0I7YqAewyVPbaRJWUQMZUFLlngGK3imG+som3Hin7d/zPTikWg64tHIxb8VXeeq6u0IRRfmQ==",
+  "integrity": "sha512-hvYyDtqhAkxg/NF7eOjCpDcIs7ksaZjk9vrBkktxTJ0liITA/FsnEgmbP9l8h3rp+zN1QIvKAUvyTCYRpyCqZQ==",
   "resolved": "\${CWD}/test/fixtures/bin-object",
 }
 `
@@ -184,7 +184,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -250,7 +250,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true and log:{level: silent} > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -316,7 +316,7 @@ Object {
 exports[`test/dir.js TAP with prepare script > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-HTzPAt8wmXNchUdisnGDSCuUgrFee5v8F6GsLc5mQd29VXiNzv4PGz71jjLSIF1wWQSB+UjLTmSJSGznF/s/Lw==",
+  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `

--- a/test/dir.js
+++ b/test/dir.js
@@ -145,7 +145,9 @@ t.test('exposes tarCreateOptions method', async t => {
       cwd: '/home/foo',
       prefix: 'package/',
       portable: true,
-      gzip: true,
+      gzip: {
+        level: 9
+      },
       mtime: new Date('1985-10-26T08:15:00.000Z'),
     },
     'should return standard options'

--- a/test/util/tar-create-options.js
+++ b/test/util/tar-create-options.js
@@ -8,7 +8,9 @@ t.match(
     cwd: '/home/foo',
     prefix: 'package/',
     portable: true,
-    gzip: true,
+    gzip: {
+      level: 9
+    },
     mtime: new Date('1985-10-26T08:15:00.000Z'),
   },
   'should return standard options'


### PR DESCRIPTION
this seems to avoid some platform related optimizations that result in integrity mismatches due to the resulting compressed output not being byte for byte identical.

it's a band-aid, but it did allow me to get the same end result in both arm and intel builds of node on my m1 mbp.

tested and found same results in:
- [x] Big Sur, arm64, node 15.11.0
- [x] Big Sur, intel, node 15.11.0
- [x] Catalina, intel, node 14.16.0
- [x] Windows 10.1, intel, node 15.0.1
- [x] Ubuntu 20.04, intel, node 14.15.4
- [x] Alpine 3.11, intel, node 15.12.0

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes https://github.com/npm/cli/issues/2846