### PR TITLE
Cache tarballs streamed through pacote

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -166,8 +166,8 @@ class FetcherBase {
   }
 
   // private, should be overridden.
-  // Note that they should *not* calculate or check integrity, but *just*
-  // return the raw tarball data stream.
+  // Note that they should *not* calculate or check integrity or cache,
+  // but *just*  return the raw tarball data stream.
   [_tarballFromResolved] () {
     throw this.notImplementedError
   }
@@ -203,7 +203,12 @@ class FetcherBase {
     // gets to the point of re-setting the integrity.
     const istream = ssri.integrityStream(this.opts)
     istream.on('integrity', i => this.integrity = i)
-    return stream.on('error', er => istream.emit('error', er)).pipe(istream)
+    const cstream = cacache.put.stream(
+      this.opts.cache,
+      `pacote:tarball:${this.from}`,
+      this.opts
+    )
+    return stream.on('error', er => istream.emit('error', er)).pipe(istream).pipe(cstream)
   }
 
   pickIntegrityAlgorithm () {

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -29,6 +29,7 @@ class RemoteFetcher extends Fetcher {
       spec: this.spec,
       integrity: this.integrity,
       algorithms: [ this.pickIntegrityAlgorithm() ],
+      cache: null, // leave the caching of the tarball up to _istream
     }
     fetch(this.resolved, fetchOpts).then(res => {
       const hash = res.headers.get('x-local-cache-hash')


### PR DESCRIPTION
Tell `fetch` not to cache it's downloaded tarballs, leave that to us

Not sure the implications of changing the return type of _istream / adding a `cacache` to the end of the pipe, too unfamiliar with streams

Fixes #73 & Fixes npm/cli#2160

Also see npm/cli#2976 for my first attempt & some discussions as to how we got here.

Also this behavior should probably be documented somewhere so it doesn't slip away again :sweat_smile:  