### PR TITLE
fix(registry): normalize registry manifests

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -3,6 +3,7 @@ const RemoteFetcher = require('./remote.js')
 const _tarballFromResolved = Symbol.for('pacote.Fetcher._tarballFromResolved')
 const pacoteVersion = require('../package.json').version
 const npa = require('npm-package-arg')
+const rpj = require('read-package-json-fast')
 const pickManifest = require('npm-pick-manifest')
 const ssri = require('ssri')
 const Minipass = require('minipass')
@@ -156,7 +157,8 @@ class RegistryFetcher extends Fetcher {
         }
         if (this.integrity)
           mani._integrity = String(this.integrity)
-        return this.package = mani
+        this.package = rpj.normalize(mani)
+        return this.package
       })
   }
 

--- a/test/registry.js
+++ b/test/registry.js
@@ -61,7 +61,7 @@ t.test('underscore, no tag or version', t => {
   return f.resolve().then(r => t.equal(r, `${registry}underscore/-/underscore-1.5.1.tgz`))
   .then(() => f.manifest()).then(m => {
     t.equal(m, f.package)
-    t.match(m, { version: '1.5.1' })
+    t.match(m, { version: '1.5.1', _id: 'underscore@1.5.1' })
     return f.manifest().then(m2 => t.equal(m, m2, 'manifest cached'))
   })
   .then(() => f.extract(me + '/underscore'))


### PR DESCRIPTION
Other manifest code paths go through read-package-json-fast, which end
up normalized through that package's `normalize` function.  Manifests
picked from the registry do not.  This adds consistency between the two.


## References
Fixes https://github.com/npm/cli/issues/3132