### PR TITLE
fix: include all dep types when building for prepare

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -123,6 +123,9 @@ class FetcherBase {
       '--include=dev',
       '--include=peer',
       '--include=optional',
+      // we need the actual things, not just the lockfile
+      '--no-package-lock-only',
+      '--no-dry-run',
     ]
   }
 

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -119,6 +119,10 @@ class FetcherBase {
       '--no-progress',
       '--no-save',
       '--no-audit',
+      // override any omit settings from the environment
+      '--include=dev',
+      '--include=peer',
+      '--include=optional',
     ]
   }
 

--- a/tap-snapshots/test/fetcher.js-fake-sudo.test.cjs
+++ b/tap-snapshots/test/fetcher.js-fake-sudo.test.cjs
@@ -46,6 +46,8 @@ Array [
   "--include=dev",
   "--include=peer",
   "--include=optional",
+  "--no-package-lock-only",
+  "--no-dry-run",
 ]
 `
 
@@ -62,6 +64,8 @@ Array [
   "--include=dev",
   "--include=peer",
   "--include=optional",
+  "--no-package-lock-only",
+  "--no-dry-run",
 ]
 `
 

--- a/tap-snapshots/test/fetcher.js-fake-sudo.test.cjs
+++ b/tap-snapshots/test/fetcher.js-fake-sudo.test.cjs
@@ -43,6 +43,9 @@ Array [
   "--no-progress",
   "--no-save",
   "--no-audit",
+  "--include=dev",
+  "--include=peer",
+  "--include=optional",
 ]
 `
 
@@ -56,6 +59,9 @@ Array [
   "--no-progress",
   "--no-save",
   "--no-audit",
+  "--include=dev",
+  "--include=peer",
+  "--include=optional",
 ]
 `
 

--- a/tap-snapshots/test/fetcher.js.test.cjs
+++ b/tap-snapshots/test/fetcher.js.test.cjs
@@ -46,6 +46,8 @@ Array [
   "--include=dev",
   "--include=peer",
   "--include=optional",
+  "--no-package-lock-only",
+  "--no-dry-run",
 ]
 `
 
@@ -62,6 +64,8 @@ Array [
   "--include=dev",
   "--include=peer",
   "--include=optional",
+  "--no-package-lock-only",
+  "--no-dry-run",
 ]
 `
 

--- a/tap-snapshots/test/fetcher.js.test.cjs
+++ b/tap-snapshots/test/fetcher.js.test.cjs
@@ -43,6 +43,9 @@ Array [
   "--no-progress",
   "--no-save",
   "--no-audit",
+  "--include=dev",
+  "--include=peer",
+  "--include=optional",
 ]
 `
 
@@ -56,6 +59,9 @@ Array [
   "--no-progress",
   "--no-save",
   "--no-audit",
+  "--include=dev",
+  "--include=peer",
+  "--include=optional",
 ]
 `
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
