### PR TITLE
rethrow git pathspec errors from git operations on hosted services

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -85,6 +85,9 @@ class GitFetcher extends Fetcher {
   [_resolvedFromHosted] (hosted) {
     return this[_resolvedFromRepo](hosted.https && hosted.https())
       .catch(er => {
+        // Throw early since we know pathspec errors will fail again if retried
+        if (er instanceof git.errors.GitPathspecError)
+          throw er
         const ssh = hosted.sshurl && hosted.sshurl()
         // no fallthrough if we can't fall through or have https auth
         if (!ssh || hosted.auth)
@@ -260,9 +263,11 @@ class GitFetcher extends Fetcher {
   // is present, otherwise ssh if the hosted type provides it
   [_cloneHosted] (ref, tmp) {
     const hosted = this.spec.hosted
-    const https = hosted.https()
     return this[_cloneRepo](hosted.https({ noCommittish: true }), ref, tmp)
       .catch(er => {
+        // Throw early since we know pathspec errors will fail again if retried
+        if (er instanceof git.errors.GitPathspecError)
+          throw er
         const ssh = hosted.sshurl && hosted.sshurl({ noCommittish: true })
         // no fallthrough if we can't fall through or have https auth
         if (!ssh || hosted.auth)

--- a/test/git.js
+++ b/test/git.js
@@ -35,6 +35,7 @@ ghi.localhostssh = {
   protocols: ['git+ssh:'],
   tarballtemplate: () => `${hostedUrl}/repo-HEAD.tgz`,
   sshurltemplate: (h) => `git://127.0.0.1:${gitPort}/${h.user}${h.committish ? `#${h.committish}` : ''}`,
+  httpstemplate: (h) => `git://127.0.0.1:${gitPort}/${h.user}${h.committish ? `#${h.committish}` : ''}`,
   shortcuttemplate: (h) => `localhostssh:${h.user}/${h.project}${h.committish ? `#${h.committish}` : ''}`,
   extract: (url) => {
     const [, user, project] = url.pathname.split('/')
@@ -616,5 +617,18 @@ require('fs').writeFileSync('log', JSON.stringify(data,0,2))
     t.throws(() => {
       require(`${path}/${base}/${other}/${base}/${other}/package.json`)
     }, 'does not continue installing once loop is detected')
+  }
+})
+
+t.test('missing branch name throws pathspec error', async (t) => {
+  const domains = ['localhostssh', 'localhosthttps', 'localhost']
+
+  for (const domain of domains) {
+    await t.rejects(new GitFetcher(`${domain}:repo/x#this-branch-does-not-exist`, {cache}).resolve(), {
+      constructor: /GitPathspecError/
+    }, domain)
+    await t.rejects(new GitFetcher(`${domain}:repo/x#this-branch-does-not-exist`, {cache}).manifest(), {
+      constructor: /GitPathspecError/
+    }, domain)
   }
 })


### PR DESCRIPTION
This rethrows git pathspec errors early since there is no point in retrying them.

In `_resolvedFromHosted` the benefit is that resolving doesn't need to be attempted again.

In `_cloneHosted` prior to this change, retrying a missing pathspec would change the error to something like `fatal: destination path '/Users/lukekarrys/.npm/_cacache/tmp/git-clone-e421e02b/.git' already exists and is not an empty directory.` which was obscuring the actual error.

With this change, this is what the error looks like in the cli:

**Old**
<img width="664" alt="Screen Shot 2021-07-02 at 12 37 22 PM" src="https://user-images.githubusercontent.com/542108/124321291-4d7fc900-db32-11eb-93b6-60f7d99e7dc8.png">

**New**
<img width="692" alt="Screen Shot 2021-07-02 at 12 15 33 PM" src="https://user-images.githubusercontent.com/542108/124320602-07763580-db31-11eb-87d9-711e52415c4d.png">

Ref: https://github.com/npm/cli/issues/3149
