### PR TITLE
fix: force gzip flush setting to Z_FULL_FLUSH

### DIFF
--- a/lib/util/tar-create-options.js
+++ b/lib/util/tar-create-options.js
@@ -5,11 +5,11 @@ const tarCreateOptions = manifest => ({
   prefix: 'package/',
   portable: true,
   gzip: {
-    // forcing the level to 9 seems to avoid some
-    // platform specific optimizations that cause
-    // integrity mismatch errors due to differing
-    // end results after compression
-    level: 9
+    // forcing the level to 9 and flush to 3 (Z_FULL_FLUSH) seems to avoid some
+    // platform specific optimizations that cause integrity mismatch errors due
+    // to differing end results after compression
+    level: 9,
+    flush: 3,
   },
 
   // ensure that package bins are always executable

--- a/tap-snapshots/test/dir.js.test.cjs
+++ b/tap-snapshots/test/dir.js.test.cjs
@@ -8,7 +8,7 @@
 exports[`test/dir.js TAP basic > extract 1`] = `
 Object {
   "from": "file:test/fixtures/abbrev",
-  "integrity": "sha512-OCm45DHz7n9f1SEllmg3Bf1zBCzsiOYxMuodMZ5ux+HMoupmkzOftyOCKH07DhAcoyfUlos2VGmYkPHDxH92yg==",
+  "integrity": "sha512-I3vTFC+lcj06Z/kKzfF46JRJ8Zo31JN0N5GkuyXETIiLpJjh5yrYXdXPC0ehnx2kgSG+kUYd3s1DyN3xam/PKg==",
   "resolved": "\${CWD}/test/fixtures/abbrev",
 }
 `
@@ -176,7 +176,7 @@ Object {
 exports[`test/dir.js TAP make bins executable > results of unpack 1`] = `
 Object {
   "from": "file:test/fixtures/bin-object",
-  "integrity": "sha512-hvYyDtqhAkxg/NF7eOjCpDcIs7ksaZjk9vrBkktxTJ0liITA/FsnEgmbP9l8h3rp+zN1QIvKAUvyTCYRpyCqZQ==",
+  "integrity": "sha512-QKG5OrNXMNSXIPX88Eg/HqD34sltojvTV06g4X+9/sKRpBR7cpa4mOQrdwnz0HZl+gH4ciwWcfXSqknsIGznjQ==",
   "resolved": "\${CWD}/test/fixtures/bin-object",
 }
 `
@@ -184,7 +184,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
+  "integrity": "sha512-bW57J7gdjHVIdnxmtEdgv9puPrNxSU6xO7pGCZkkPLsrgf5ArHKvg2CflypkNhq5d9oYyFfYfOOFDukn6nYL6Q==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -250,7 +250,7 @@ Object {
 exports[`test/dir.js TAP responds to foregroundScripts: true and log:{level: silent} > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
+  "integrity": "sha512-bW57J7gdjHVIdnxmtEdgv9puPrNxSU6xO7pGCZkkPLsrgf5ArHKvg2CflypkNhq5d9oYyFfYfOOFDukn6nYL6Q==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `
@@ -316,7 +316,7 @@ Object {
 exports[`test/dir.js TAP with prepare script > extract 1`] = `
 Object {
   "from": "file:test/fixtures/prepare-script",
-  "integrity": "sha512-+bTA3RvkXgLMM1PIzfcwXkiiSYzCBHT6Jrqo8yt3owZtMhOnBomH1Dc0949tVurdyPk7WcrKitvsRnXRPCD4sQ==",
+  "integrity": "sha512-bW57J7gdjHVIdnxmtEdgv9puPrNxSU6xO7pGCZkkPLsrgf5ArHKvg2CflypkNhq5d9oYyFfYfOOFDukn6nYL6Q==",
   "resolved": "\${CWD}/test/fixtures/prepare-script",
 }
 `


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
i tested a full matrix of combinations for both `flush` and `level` (i also did some experimenting with `chunkSize` but that yielded nothing meaningful), the combinations that resulted in identical packed results across osx/m1, osx/intel, ubuntu/intel, and arch/intel are as follows:

```
match: { flush: 0, level: 0 }
match: { flush: 1, level: 0 }
match: { flush: 2, level: 0 }
match: { flush: 3, level: 0 }
match: { flush: 3, level: 9 }
```

since setting the level to `0` is effectively no compression, that felt like a non-starter, so i went with setting `flush` to `Z_FULL_FLUSH`. this does yield a bit of a size increase as compared to the default of `Z_NO_FLUSH` (~15% on my test package which is 5.1mb unpacked), but that feels like a pretty reasonable tradeoff to get a bit more consistency

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #76 