### PR TITLE
preserve git+ssh url for non-hosted repos

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -50,7 +50,7 @@ class GitFetcher extends Fetcher {
       // use hosted.tarball() when we shell to RemoteFetcher later
       this.resolved = this.spec.hosted
         ? repoUrl(this.spec.hosted, { noCommittish: false })
-        : this.spec.fetchSpec + '#' + this.spec.gitCommittish
+        : this.spec.rawSpec
     } else
       this.resolvedSha = ''
   }

--- a/test/git.js
+++ b/test/git.js
@@ -541,6 +541,14 @@ t.test('resolved is a git+ssh url for hosted repos that support it', t => {
   t.end()
 })
 
+t.test('resolved preserves git+ssh url for non-hosted repos', t => {
+  const hash = '0000000000000000000000000000000000000000'
+  const url = `git+ssh://git@test/x/y.git#${hash}`
+  const gf = new GitFetcher(url, {})
+  t.equal(gf.resolved, url)
+  t.end()
+})
+
 t.test('fall back to ssh url if https url fails or is missing', t => {
   const gf = new GitFetcher(`localhostssh:repo/x`, {cache})
   return gf.extract(`${me}/localhostssh`).then(({resolved}) =>


### PR DESCRIPTION
We had the same issue described here: https://github.com/npm/cli/issues/3537
Running `npm install` with only the `package.json` and our own private git repo with a commit hash resulted in an `EUNSUPPORTEDPROTOCOL` error. While testing we noticed that this only happens when a commit hash is defined.

I did some digging through the source code and found that this is caused by the resolved URL in pacote. This can be easily reproduced using the pacote CLI: 
```
$ pacote resolve git+ssh://git@test/x/y.git#0000000000000000000000000000000000000000
ssh://git@test/x/y.git#0000000000000000000000000000000000000000
```

The [`repoUrl()`](https://github.com/npm/pacote/blob/latest/lib/git.js#L32) function has a [comment](https://github.com/npm/pacote/blob/latest/lib/git.js#L31) that mentions that the `git+` is suppressed and has to be added back which is done using the [`addGitPlus()`](https://github.com/npm/pacote/blob/latest/lib/git.js#L37) function. But the `repoUrl()` function is only called for hosted repos. For non-hosted repos, the `fetchSpec` (which has no `git+`) and the hash are used to generate the `resolved` URL. This results in the described behaviour. 

In theory `resolved` doesn't have to be set here for non-hosted repos because it would be filled using the [`addGitSha()`](https://github.com/npm/pacote/blob/latest/lib/util/add-git-sha.js#L11) function based on the `rawSpec`. But not setting it at all breaks existing tests and makes it harder to use the `resolved` URL in tests. I think the best solution here is to use the `rawSpec` as `resolved` URL for non-hosted repos like the `addGitSha()` function would do anyway. I also considered using the `addGitPlus()` function on `fetchSpec` but this can cause `git+git` URLs which break some tests.

I've done that and also added a test for this case, which fails without the change.

