### PR TITLE
fix: reject tryExtract after rimraf completes

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -68,8 +68,6 @@ function extract (spec, dest, opts) {
 
 function tryExtract (spec, tarStream, dest, opts) {
   return new BB((resolve, reject) => {
-    tarStream.on('error', reject)
-
     rimraf(dest)
       .then(() => mkdirp(dest))
       .then((made) => {
@@ -82,6 +80,10 @@ function tryExtract (spec, tarStream, dest, opts) {
         }
       })
       .then(() => {
+        // we've waited till now to catch errors reading the stream because we
+        // don't want to reject while the previous steps are still running.
+        tarStream.on('error', reject)
+
         const xtractor = extractStream(spec, dest, opts)
         xtractor.on('error', reject)
         xtractor.on('close', resolve)

--- a/lib/with-tarball-stream.js
+++ b/lib/with-tarball-stream.js
@@ -102,6 +102,11 @@ function withTarballStream (spec, opts, streamHandler) {
               opts = opts.concat({ integrity: i })
             })
           }
+          // call added error listeners with any errors thrown before the listener was added.
+          // otherwise errors emitted before a listener is added are lost.
+          tardata.once('error', err => tardata.on('newListener', (ev, l) => {
+            if (ev === 'error') { l(err) }
+          }))
           return BB.try(() => streamHandler(tardata))
             .catch(err => {
               // Retry once if we have a cache, to clear up any weird conditions.


### PR DESCRIPTION
Previously tryExtract may be rejected by an error on tarStream while
rimraf is still running. if withTarStream attempts another stream source
pacote may start extracting to a folder while rimraf is deleting it's
contents. This can cause warnings and errors in the tar extraction or
worse, tar can successfully extract the stream without any warnings but
files will be removed after extraction.

This commit simply delays rejecting on stream errors till directory
setup has completed.

## References
Fixes #87
