### PR TITLE
fix: reify git dependencies that have workspaces

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -154,12 +154,12 @@ class GitFetcher extends Fetcher {
     return this[_readPackageJson](dir + '/package.json').then(mani => {
       // no need if we aren't going to do any preparation.
       const scripts = mani.scripts
-      if (!scripts || !(
+      if (!mani.workspaces && (!scripts || !(
         scripts.postinstall ||
           scripts.build ||
           scripts.preinstall ||
           scripts.install ||
-          scripts.prepare)) {
+          scripts.prepare))) {
         return
       }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Draft until I write tests for this

This change will reify a git dependency if that git dependency has workspaces defined.

This is necessary because for git dependencies on a known hosting provider, we actually download an archive file rather than cloning the repository. That's all well and good, but `tar` refuses to unpack symlinks which is how a workspace tends to be stored in `node_modules` in a git repository that happens to have `node_modules` checked in. The end result today is that `npm i -g npm/cli#release-next` gives you a broken installation because all of the workspace modules are missing.

We could potentially extend the check so that it requires that the workspaces are defined _and_ bundled dependencies are in use _and_ a node_modules directory is present to be as specific as possible, but I'm not sure if that's overkill...

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
