### PR TITLE
fix: run prepack lifecycle scripts on git fetcher

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -159,6 +159,7 @@ class GitFetcher extends Fetcher {
           scripts.build ||
           scripts.preinstall ||
           scripts.install ||
+          scripts.prepack ||
           scripts.prepare))) {
         return
       }


### PR DESCRIPTION
When running prepare steps for git dependencies, we should also check
for `prepack` scripts and make sure the prepare steps are run in case
one is found.


<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References

Fixes: https://github.com/npm/cli/issues/4391
