### PR TITLE
feat: add option to not replace magic registry host

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -105,6 +105,9 @@ class FetcherBase {
       this[_readPackageJson] = readPackageJsonFast
     }
 
+    // config values: npmjs (default), never
+    this.replaceRegistryHost = opts.replaceRegistryHost === 'never' ? 'never' : 'npmjs'
+
     this.defaultTag = opts.defaultTag || 'latest'
     this.registry = removeTrailingSlashes(opts.registry || 'https://registry.npmjs.org')
 

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -13,7 +13,9 @@ class RemoteFetcher extends Fetcher {
   constructor (spec, opts) {
     super(spec, opts)
     this.resolved = this.spec.fetchSpec
-    if (magic.test(this.resolved) && !magic.test(this.registry + '/')) {
+    if (this.replaceRegistryHost === 'npmjs'
+      && magic.test(this.resolved)
+      && !magic.test(this.registry + '/')) {
       this.resolved = this.resolved.replace(magic, this.registry + '/')
     }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@npmcli/template-oss": "^2.9.2",
     "hosted-git-info": "^5.0.0",
     "mutate-fs": "^2.1.1",
+    "nock": "^13.2.4",
     "npm-registry-mock": "^1.3.1",
     "tap": "^15.1.6"
   },

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -518,3 +518,17 @@ t.test('set integrity, pick default algo', t => {
   t.equal(g.pickIntegrityAlgorithm(), 'sha256')
   t.end()
 })
+
+t.test('replace opts defaults to npmjs', t => {
+  const f = new FileFetcher('pkg.tgz', {
+  })
+  t.equal(f.replaceRegistryHost, 'npmjs')
+  t.end()
+})
+t.test('replace opts never', t => {
+  const f = new FileFetcher('pkg.tgz', {
+    replaceRegistryHost: 'never',
+  })
+  t.equal(f.replaceRegistryHost, 'never')
+  t.end()
+})

--- a/test/fixtures/tnock.js
+++ b/test/fixtures/tnock.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const nock = require('nock')
+
+module.exports = tnock
+function tnock (t, host) {
+  const server = nock(host)
+  nock.disableNetConnect()
+  t.teardown(function () {
+    nock.enableNetConnect()
+    server.done()
+  })
+  return server
+}


### PR DESCRIPTION
By default, a package manifest might contain dist tarballs with "registry.npmjs.org" hosts, which will be replaced automatically with the configured registry host.

This PR adds an option, `replaceRegistryHost`, which is `true` by default.

When set to `false`, "registry.npmjs.org" is no longer treated like a magic value.