### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -110,7 +110,7 @@ const parseArg = arg => {
   const k = split.shift()
   const v = split.join('=')
   const no = /^no-/.test(k) && !v
-  const key = (no ? k.substr(3) : k)
+  const key = (no ? k.slice(3) : k)
     .replace(/^tag$/, 'defaultTag')
     .replace(/-([a-z])/g, (_, c) => c.toUpperCase())
   const value = v ? v.replace(/^~/, process.env.HOME) : !no

--- a/lib/util/trailing-slashes.js
+++ b/lib/util/trailing-slashes.js
@@ -2,7 +2,7 @@ const removeTrailingSlashes = (input) => {
   // in order to avoid regexp redos detection
   let output = input
   while (output.endsWith('/')) {
-    output = output.substr(0, output.length - 1)
+    output = output.slice(0, -1)
   }
   return output
 }

--- a/tap-snapshots/test/dir.js.test.cjs
+++ b/tap-snapshots/test/dir.js.test.cjs
@@ -8,7 +8,7 @@
 exports[`test/dir.js TAP basic > extract 1`] = `
 Object {
   "from": "file:test/fixtures/abbrev",
-  "integrity": "sha512-TP/sks9uY1WtzkFdIg2xVCud1JfysnFoNeA2P7J3CHd7l9Zlcllrk4gXfw/ABzyRU2aVrTKzoS9Bkrre6YqAFw==",
+  "integrity": "sha512-4LQrO8XIPkwgx2wanFZU5bCNmzB1dzTbDtgozDs2uqGLj0x1De97lOP3BFEtlsZDFOquwrJt0IHsjEFfgfDyVA==",
   "resolved": "\${CWD}/test/fixtures/abbrev",
 }
 `

--- a/test/fixtures/abbrev/abbrev.js
+++ b/test/fixtures/abbrev/abbrev.js
@@ -60,7 +60,7 @@ function abbrev (list) {
       abbrevs[current] = current
       continue
     }
-    for (var a = current.substr(0, j); j <= cl; j++) {
+    for (var a = current.slice(0, j); j <= cl; j++) {
       abbrevs[a] = current
       a += current.charAt(j)
     }


### PR DESCRIPTION
.substr() is deprecated so we replace it with .slice() which works similarily but isn't deprecated


Credit: Tobias Speicher <rootcommander@gmail.com>