### PR TITLE
feat: add always option to replaceRegistryHost

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -105,8 +105,15 @@ class FetcherBase {
       this[_readPackageJson] = readPackageJsonFast
     }
 
-    // config values: npmjs (default), never
-    this.replaceRegistryHost = opts.replaceRegistryHost === 'never' ? 'never' : 'npmjs'
+    // config values: npmjs (default), never, always
+    // we don't want to mutate the original value
+    if (opts.replaceRegistryHost !== 'never'
+      && opts.replaceRegistryHost !== 'always'
+    ) {
+      this.replaceRegistryHost = 'npmjs'
+    } else {
+      this.replaceRegistryHost = opts.replaceRegistryHost
+    }
 
     this.defaultTag = opts.defaultTag || 'latest'
     this.registry = removeTrailingSlashes(opts.registry || 'https://registry.npmjs.org')

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -5,7 +5,8 @@ const pacoteVersion = require('../package.json').version
 const fetch = require('npm-registry-fetch')
 const Minipass = require('minipass')
 // The default registry URL is a string of great magic.
-const magic = /^https?:\/\/registry\.npmjs\.org\//
+const magicHost = /^https?:\/\/registry\.npmjs\.org\//
+const allHost = /^https?:\/\/([^/?#]+)(?:[/?#]|$)/
 
 const _cacheFetches = Symbol.for('pacote.Fetcher._cacheFetches')
 const _headers = Symbol('_headers')
@@ -14,9 +15,12 @@ class RemoteFetcher extends Fetcher {
     super(spec, opts)
     this.resolved = this.spec.fetchSpec
     if (this.replaceRegistryHost === 'npmjs'
-      && magic.test(this.resolved)
-      && !magic.test(this.registry + '/')) {
-      this.resolved = this.resolved.replace(magic, this.registry + '/')
+      && magicHost.test(this.resolved)
+      && !magicHost.test(this.registry + '/')) {
+      this.resolved = this.resolved.replace(magicHost, this.registry + '/')
+    } else if (this.replaceRegistryHost === 'always'
+      && allHost.test(this.resolved)) {
+      this.resolved = this.resolved.replace(allHost, this.registry + '/')
     }
 
     // nam is a fermented pork sausage that is good to eat

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -5,8 +5,7 @@ const pacoteVersion = require('../package.json').version
 const fetch = require('npm-registry-fetch')
 const Minipass = require('minipass')
 // The default registry URL is a string of great magic.
-const magicHost = /^https?:\/\/registry\.npmjs\.org\//
-const allHost = /^https?:\/\/([^/?#]+)(?:[/?#]|$)/
+const magicHost = 'https://registry.npmjs.org'
 
 const _cacheFetches = Symbol.for('pacote.Fetcher._cacheFetches')
 const _headers = Symbol('_headers')
@@ -14,13 +13,13 @@ class RemoteFetcher extends Fetcher {
   constructor (spec, opts) {
     super(spec, opts)
     this.resolved = this.spec.fetchSpec
-    if (this.replaceRegistryHost === 'npmjs'
-      && magicHost.test(this.resolved)
-      && !magicHost.test(this.registry + '/')) {
-      this.resolved = this.resolved.replace(magicHost, this.registry + '/')
-    } else if (this.replaceRegistryHost === 'always'
-      && allHost.test(this.resolved)) {
-      this.resolved = this.resolved.replace(allHost, this.registry + '/')
+    const resolvedURL = new URL(this.resolved)
+    if (
+      (this.replaceRegistryHost === 'npmjs'
+        && resolvedURL.origin === magicHost)
+      || this.replaceRegistryHost === 'always'
+    ) {
+      this.resolved = new URL(resolvedURL.pathname, this.registry).href
     }
 
     // nam is a fermented pork sausage that is good to eat

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -531,3 +531,10 @@ t.test('replace opts never', t => {
   t.equal(f.replaceRegistryHost, 'never')
   t.end()
 })
+t.test('replace opts always', t => {
+  const f = new FileFetcher('pkg.tgz', {
+    replaceRegistryHost: 'always',
+  })
+  t.equal(f.replaceRegistryHost, 'always')
+  t.end()
+})


### PR DESCRIPTION
The pacote option `replaceRegistryHost` currently supports values "npmjs" (default) and "never".
This PR adds "always". When "always" is set, the registry host in the tarball url of the packument is always replaced with the current `registry`, regardless of its packument reference value.
