### PR TITLE
fix: pass prefix and workspaces to npm-packlist

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -63,10 +63,12 @@ class DirFetcher extends Fetcher {
     stream.resolved = this.resolved
     stream.integrity = this.integrity
 
+    const { prefix, workspaces } = this.opts
+
     // run the prepare script, get the list of files, and tar it up
     // pipe to the stream, and proxy errors the chain.
     this[_prepareDir]()
-      .then(() => packlist({ path: this.resolved }))
+      .then(() => packlist({ path: this.resolved, prefix, workspaces }))
       .then(files => tar.c(tarCreateOptions(this.package), files)
         .on('error', er => stream.emit('error', er)).pipe(stream))
       .catch(er => stream.emit('error', er))


### PR DESCRIPTION
this sets us up for changes to the cli itself and npm-packlist that will ensure we respect .gitignore and .npmignore files from a workspace root when we're packing a workspace
