### PR TITLE
fix(packument): eliminate _cached field

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ For Pacote's purposes, the following fields are relevant:
 * `time` In the full packument, an object mapping version numbers to
   publication times, for the `opts.before` functionality.
 
-Pacote adds the following fields, regardless of the accept header:
+Pacote adds the following field, regardless of the accept header:
 
-* `_cached` Whether the packument was fetched from the network or the local cache.
 * `_contentLength` The size of the packument.

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -127,6 +127,7 @@ class RegistryFetcher extends Fetcher {
       defaultTag: this.defaultTag,
       before: this.before,
     })
+    mani._cached = packument._cached
     /* XXX add ETARGET and E403 revalidation of cached packuments here */
 
     // add _resolved and _integrity from dist object

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -97,7 +97,6 @@ class RegistryFetcher extends Fetcher {
         integrity: null,
       })
       const packument = await res.json()
-      packument._cached = res.headers.has('x-local-cache')
       packument._contentLength = +res.headers.get('content-length')
       if (this.packumentCache) {
         this.packumentCache.set(this.packumentUrl, packument)
@@ -128,7 +127,6 @@ class RegistryFetcher extends Fetcher {
       before: this.before,
     })
     mani = rpj.normalize(mani)
-    mani._cached = packument._cached
     /* XXX add ETARGET and E403 revalidation of cached packuments here */
 
     // add _resolved and _integrity from dist object


### PR DESCRIPTION
I'm interested in telling whether the result of `pacote.manifest()` came from the registry or from the cacache. Is that what the existing packument `_cached` field indicates? https://github.com/npm/pacote/blob/298df450c03af17c069b8e40834d0154e801b61e/lib/registry.js#L77

If so, does it make sense to add that field to `pacote.manifest()` results, and is this PR the correct way/location to do it?