### PR TITLE
feat: replaceRegistryHost can now be a hostname

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -105,15 +105,10 @@ class FetcherBase {
       this[_readPackageJson] = readPackageJsonFast
     }
 
-    // config values: npmjs (default), never, always
-    // we don't want to mutate the original value
-    if (opts.replaceRegistryHost !== 'never'
-      && opts.replaceRegistryHost !== 'always'
-    ) {
-      this.replaceRegistryHost = 'npmjs'
-    } else {
-      this.replaceRegistryHost = opts.replaceRegistryHost
-    }
+    // rrh is a registry hostname or 'never' or 'always'
+    // defaults to registry.npmjs.org
+    this.replaceRegistryHost = (!opts.replaceRegistryHost || opts.replaceRegistryHost === 'npmjs') ?
+      'registry.npmjs.org' : opts.replaceRegistryHost
 
     this.defaultTag = opts.defaultTag || 'latest'
     this.registry = removeTrailingSlashes(opts.registry || 'https://registry.npmjs.org')

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -4,8 +4,6 @@ const _tarballFromResolved = Symbol.for('pacote.Fetcher._tarballFromResolved')
 const pacoteVersion = require('../package.json').version
 const fetch = require('npm-registry-fetch')
 const Minipass = require('minipass')
-// The default registry URL is a string of great magic.
-const magicHost = 'https://registry.npmjs.org'
 
 const _cacheFetches = Symbol.for('pacote.Fetcher._cacheFetches')
 const _headers = Symbol('_headers')
@@ -14,11 +12,9 @@ class RemoteFetcher extends Fetcher {
     super(spec, opts)
     this.resolved = this.spec.fetchSpec
     const resolvedURL = new URL(this.resolved)
-    if (
-      (this.replaceRegistryHost === 'npmjs'
-        && resolvedURL.origin === magicHost)
-      || this.replaceRegistryHost === 'always'
-    ) {
+    if (this.replaceRegistryHost !== 'never'
+      && (this.replaceRegistryHost === 'always'
+      || this.replaceRegistryHost === resolvedURL.host)) {
       this.resolved = new URL(resolvedURL.pathname, this.registry).href
     }
 

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -518,10 +518,10 @@ t.test('set integrity, pick default algo', t => {
   t.end()
 })
 
-t.test('replace opts defaults to npmjs', t => {
+t.test('replace opts defaults to default registry', t => {
   const f = new FileFetcher('pkg.tgz', {
   })
-  t.equal(f.replaceRegistryHost, 'npmjs')
+  t.equal(f.replaceRegistryHost, 'registry.npmjs.org')
   t.end()
 })
 t.test('replace opts never', t => {

--- a/test/registry.js
+++ b/test/registry.js
@@ -307,7 +307,7 @@ t.test('option replaceRegistryHost', rhTest => {
       cache: join(testdir, 'cache'),
       fullReadJson: true,
     })
-    ct.equal(fetcher.replaceRegistryHost, 'npmjs')
+    ct.equal(fetcher.replaceRegistryHost, 'registry.npmjs.org')
     const manifest = await fetcher.manifest()
     ct.equal(manifest.dist.tarball, 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz')
     const tarball = await fetcher.tarball()
@@ -328,7 +328,7 @@ t.test('option replaceRegistryHost', rhTest => {
       fullReadJson: true,
       replaceRegistryHost: 'npmjs',
     })
-    ct.equal(fetcher.replaceRegistryHost, 'npmjs')
+    ct.equal(fetcher.replaceRegistryHost, 'registry.npmjs.org')
     const manifest = await fetcher.manifest()
     ct.equal(manifest.dist.tarball, 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz')
     const tarball = await fetcher.tarball()


### PR DESCRIPTION
Feedback from adding this feature to the main CLI lead to the idea that this value could be a host, rather than an enum of ('npmjs', 'always', 'never').

Now the valid values are ('npmjs', 'always', 'never', <hostname>). 'npmjs' is now an alias to 'registry.npmjs.org'