### PR TITLE
feat: bump npm-packlist for workspace awareness

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "minipass": "^3.1.6",
     "mkdirp": "^1.0.4",
     "npm-package-arg": "^9.0.0",
-    "npm-packlist": "^5.0.0",
+    "npm-packlist": "^5.1.0",
     "npm-pick-manifest": "^7.0.0",
     "npm-registry-fetch": "^13.0.1",
     "proc-log": "^2.0.0",


### PR DESCRIPTION
this raises the npm-packlist dependency to the required version to allow for workspace awareness. the necessary change here was made in #173
