### PR TITLE
docs: add some fields to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ In addition to the common `package.json` fields, manifests include:
   artifact can be found.
 * `manifest._from` A normalized form of the spec passed in as an argument.
 * `manifest._integrity` The integrity value for the package artifact.
+* `manifest._id` The canonical spec of this package version: name@version.
 * `manifest.dist` Registry manifests (those included in a packument) have a
   `dist` object.  Only `tarball` is required, though at least one of
   `shasum` or `integrity` is almost always present.
@@ -274,3 +275,8 @@ For Pacote's purposes, the following fields are relevant:
   `foo@latest` gets turned into `foo@1.2.3`.
 * `time` In the full packument, an object mapping version numbers to
   publication times, for the `opts.before` functionality.
+
+Pacote adds the following fields, regardless of the accept header:
+
+* `_cached` Whether the packument was fetched from the network or the local cache.
+* `_contentLength` The size of the packument.


### PR DESCRIPTION
Does it make sense to add the manifest [`_id`](https://github.com/npm/read-package-json-fast#:~:text=set%20the%20_id%20property%20if%20name%20and%20version%20are%20set.%20(this%20is%20load-bearing%20in%20a%20few%20places%20within%20the%20npm%20cli.)) field and the packument [`_cached` and `_contentLength`](https://github.com/npm/pacote/blob/298df450c03af17c069b8e40834d0154e801b61e/lib/registry.js#L77-L78) fields to the README, along with the other fields that Pacote adds? That's what this PR does.