### PR TITLE
nlf/reduce reuse recycle

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -18,6 +18,7 @@ const removeTrailingSlashes = require('./util/trailing-slashes.js')
 const getContents = require('@npmcli/installed-package-contents')
 const readPackageJsonFast = require('read-package-json-fast')
 const readPackageJson = promisify(require('read-package-json'))
+const Minipass = require('minipass')
 
 // we only change ownership on unix platforms, and only if uid is 0
 const selfOwner = process.getuid && process.getuid() === 0 ? {
@@ -224,18 +225,18 @@ class FetcherBase {
   }
 
   [_istream] (stream) {
-    // everyone will need one of these, either for verifying or calculating
-    // We always set it, because we have might only have a weak legacy hex
-    // sha1 in the packument, and this MAY upgrade it to a stronger algo.
-    // If we had an integrity, and it doesn't match, then this does not
-    // override that error; the istream will raise the error before it
-    // gets to the point of re-setting the integrity.
-    const istream = ssri.integrityStream(this.opts)
-    istream.on('integrity', i => this.integrity = i)
-    stream.on('error', er => istream.emit('error', er))
-
-    // if not caching this, just pipe through to the istream and return it
+    // if not caching this, just return it
     if (!this.opts.cache || !this[_cacheFetches]) {
+      // instead of creating a new integrity stream, we only piggyback on the
+      // provided stream's events
+      if (stream.hasIntegrityEmitter) {
+        stream.on('integrity', i => this.integrity = i)
+        return stream
+      }
+
+      const istream = ssri.integrityStream(this.opts)
+      istream.on('integrity', i => this.integrity = i)
+      stream.on('error', err => istream.emit('error', err))
       return stream.pipe(istream)
     }
 
@@ -243,21 +244,23 @@ class FetcherBase {
     // but then pipe from the original tarball stream into the cache as well.
     // To do this without losing any data, and since the cacache put stream
     // is not a passthrough, we have to pipe from the original stream into
-    // the cache AFTER we pipe into the istream.  Since the cache stream
+    // the cache AFTER we pipe into the middleStream.  Since the cache stream
     // has an asynchronous flush to write its contents to disk, we need to
-    // defer the istream end until the cache stream ends.
-    stream.pipe(istream, { end: false })
+    // defer the middleStream end until the cache stream ends.
+    const middleStream = new Minipass()
+    stream.on('error', err => middleStream.emit('error', err))
+    stream.pipe(middleStream, { end: false })
     const cstream = cacache.put.stream(
       this.opts.cache,
       `pacote:tarball:${this.from}`,
       this.opts
     )
+    cstream.on('integrity', i => this.integrity = i)
+    cstream.on('error', err => stream.emit('error', err))
     stream.pipe(cstream)
-    // defer istream end until after cstream
-    // cache write errors should not crash the fetch, this is best-effort.
-    cstream.promise().catch(() => {}).then(() => istream.end())
 
-    return istream
+    cstream.promise().catch(() => {}).then(() => middleStream.end())
+    return middleStream
   }
 
   pickIntegrityAlgorithm () {

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -35,6 +35,8 @@ class RemoteFetcher extends Fetcher {
 
   [_tarballFromResolved] () {
     const stream = new Minipass()
+    stream.hasIntegrityEmitter = true
+
     const fetchOpts = {
       ...this.opts,
       headers: this[_headers](),
@@ -42,16 +44,19 @@ class RemoteFetcher extends Fetcher {
       integrity: this.integrity,
       algorithms: [this.pickIntegrityAlgorithm()],
     }
-    fetch(this.resolved, fetchOpts).then(res => {
-      const hash = res.headers.get('x-local-cache-hash')
-      if (hash) {
-        this.integrity = decodeURIComponent(hash)
-      }
 
+    fetch(this.resolved, fetchOpts).then(res => {
       res.body.on('error',
         /* istanbul ignore next - exceedingly rare and hard to simulate */
         er => stream.emit('error', er)
-      ).pipe(stream)
+      )
+
+      res.body.on('integrity', i => {
+        this.integrity = i
+        stream.emit('integrity', i)
+      })
+
+      res.body.pipe(stream)
     }).catch(er => stream.emit('error', er))
 
     return stream

--- a/map.js
+++ b/map.js
@@ -1,1 +1,0 @@
-module.exports = test => test.replace(/^test[\\/]/, 'lib/')

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "template-oss-apply": "template-oss-apply --force"
   },
   "tap": {
-    "timeout": 300,
-    "coverage-map": "map.js"
+    "timeout": 300
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^3.0.1",


### PR DESCRIPTION
- chore: remove tap coverage map
- feat: allow reuse of external integrity stream

this removes another redundant integrity stream from our chain. in order to remove the stream from _every_ code path, we would have to remove integrity testing for local filesystem installs, which would require some care since we _do_ want the integrity when packing a brand new tarball for publish but we _don't_ want it when we're installing a tarball from the filesystem into our project. making this change would also end up making the caching pacote does for these local tarballs completely pointless since we'll never look it up by hash. something to ponder for certain.

the first portion of this change is that we will not use a duplicate integrity stream for requests that have caching disabled if they come with an integrity emitter already attached, which is every file coming from npm-registry-fetch with a known integrity (i.e. everything from the registry at least) that is not an uncacheable response per http semantics.

the second portion removes the duplicate integrity stream for anything that we're writing to the cache, and instead receives the integrity event from cacache directly and uses that.

most notably - we will no longer try to _add_ a sha512 for packages that were published with only a sha1. doing this causes us to calculate integrity for each sha1 package twice for no real benefit. it's simpler to just use the sha1 as is and let the registry team complete their work of rewriting packuments with sha512s in them.
