### PR TITLE
feat: pacote now optionally takes a tree when preparing directories

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -3,6 +3,7 @@ const FileFetcher = require('./file.js')
 const Minipass = require('minipass')
 const tarCreateOptions = require('./util/tar-create-options.js')
 const packlist = require('npm-packlist')
+const Arborist = require('@npmcli/arborist')
 const tar = require('tar')
 const _prepareDir = Symbol('_prepareDir')
 const { resolve } = require('path')
@@ -68,7 +69,13 @@ class DirFetcher extends Fetcher {
     // run the prepare script, get the list of files, and tar it up
     // pipe to the stream, and proxy errors the chain.
     this[_prepareDir]()
-      .then(() => packlist({ path: this.resolved, prefix, workspaces }))
+      .then(async () => {
+        if (!this.tree) {
+          const arb = new Arborist({ path: this.resolved })
+          this.tree = await arb.loadActual()
+        }
+        return packlist(this.tree, { path: this.resolved, prefix, workspaces })
+      })
       .then(files => tar.c(tarCreateOptions(this.package), files)
         .on('error', er => stream.emit('error', er)).pipe(stream))
       .catch(er => stream.emit('error', er))

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -72,6 +72,7 @@ class FetcherBase {
 
     this.cache = opts.cache || cacheDir()
     this.resolved = opts.resolved || null
+    this.tree = opts.tree || null
 
     // default to caching/verifying with sha512, that's what we usually have
     // need to change this default, or start overriding it, when sha512

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ]
   },
   "devDependencies": {
+    "@npmcli/arborist": "^6.0.0 || ^6.0.0-pre.0",
     "@npmcli/eslint-config": "^3.1.0",
     "@npmcli/template-oss": "4.4.2",
     "hosted-git-info": "^5.0.0",
@@ -54,7 +55,7 @@
     "minipass": "^3.1.6",
     "mkdirp": "^1.0.4",
     "npm-package-arg": "^9.0.0",
-    "npm-packlist": "^6.0.0",
+    "npm-packlist": "^7.0.0 || ^7.0.0-pre.0",
     "npm-pick-manifest": "^7.0.0",
     "npm-registry-fetch": "^13.0.1",
     "proc-log": "^2.0.0",
@@ -64,6 +65,9 @@
     "rimraf": "^3.0.2",
     "ssri": "^9.0.0",
     "tar": "^6.1.11"
+  },
+  "peerDependencies": {
+    "@npmcli/arborist": "^6.0.0 || ^6.0.0-pre.0"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"

--- a/test/fixtures/npm-mock.js
+++ b/test/fixtures/npm-mock.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const { argv, env } = process
+
+const pnp = env._PACOTE_NO_PREPARE_ || ''
+const pacotePath = env._PACOTE_TEST_PATH_
+const pacoteOpts = env._PACOTE_TEST_OPTS_
+
+const data = {
+  argv,
+  noPrepare: pnp ? pnp.split('\\n') : [],
+  cwd: process.cwd(),
+}
+
+if (data.noPrepare.length > 5) {
+  throw new Error('infinite regress detected!')
+}
+
+// just an incredibly rudimentary package manager
+const pkg = require(process.cwd() + '/package.json')
+const pacote = require(pacotePath)
+for (const [name, spec] of Object.entries(pkg.dependencies)) {
+  pacote.extract(spec, process.cwd() + '/' + name, {
+    npmBin: __filename,
+    ...JSON.parse(pacoteOpts),
+  })
+}
+
+require('fs').writeFileSync('log', JSON.stringify(data, 0, 2))


### PR DESCRIPTION
If a tree is not passed in, then pacote will create one with
`loadActual` and the resolved path to the directory it is preparing.

BREAKING CHANGE: `pacote` now has a peer dependency on
`@npmcli/arborist`.
