### PR TITLE
lk/npa breaking

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -66,7 +66,7 @@ jobs:
           # This only sets the conventional commit prefix. This workflow can't reliably determine
           # what the breaking change is though. If a BREAKING CHANGE message is required then
           # this PR check will fail and the commit will be amended with stafftools
-          if [[ "${{ steps.dependabot-metadata.outputs.update-type }}" == "version-update:semver-major" ]]; then
+          if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-major" ]]; then
             prefix='feat!'
           else
             prefix='chore!'
@@ -90,7 +90,7 @@ jobs:
       # and attempt to commit and push again. This is helpful because we will have a commit
       # with the correct prefix that we can then --amend with @npmcli/stafftools later.
       - name: Push All Changes Except Workflows
-        if: steps.apply.outputs.changes && steps.push-all.outcome == 'failure'
+        if: steps.apply.outputs.changes && steps.push.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -3,7 +3,6 @@ const RemoteFetcher = require('./remote.js')
 const _tarballFromResolved = Symbol.for('pacote.Fetcher._tarballFromResolved')
 const pacoteVersion = require('../package.json').version
 const removeTrailingSlashes = require('./util/trailing-slashes.js')
-const npa = require('npm-package-arg')
 const rpj = require('read-package-json-fast')
 const pickManifest = require('npm-pick-manifest')
 const ssri = require('ssri')
@@ -28,12 +27,6 @@ class RegistryFetcher extends Fetcher {
     // already.
     this.packumentCache = this.opts.packumentCache || null
 
-    // handle case when npm-package-arg guesses wrong.
-    if (this.spec.type === 'tag' &&
-        this.spec.rawSpec === '' &&
-        this.defaultTag !== 'latest') {
-      this.spec = npa(`${this.spec.name}@${this.defaultTag}`)
-    }
     this.registry = fetch.pickRegistry(spec, opts)
     this.packumentUrl = removeTrailingSlashes(this.registry) + '/' +
       this.spec.escapedName

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cacache": "^17.0.0",
     "fs-minipass": "^2.1.0",
     "minipass": "^3.1.6",
-    "npm-package-arg": "^9.0.0",
+    "npm-package-arg": "^10.0.0",
     "npm-packlist": "^7.0.0",
     "npm-pick-manifest": "^8.0.0",
     "npm-registry-fetch": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "@npmcli/arborist": "^6.0.0 || ^6.0.0-pre.0",
-    "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.6.0",
-    "hosted-git-info": "^5.0.0",
+    "@npmcli/eslint-config": "^3.1.0",
+    "@npmcli/template-oss": "4.5.1",
+    "hosted-git-info": "^6.0.0",
     "mutate-fs": "^2.1.1",
     "nock": "^13.2.4",
     "npm-registry-mock": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@npmcli/arborist": "^6.0.0 || ^6.0.0-pre.0",
     "@npmcli/eslint-config": "^3.1.0",
-    "@npmcli/template-oss": "4.5.1",
+    "@npmcli/template-oss": "4.6.2",
     "hosted-git-info": "^6.0.0",
     "mutate-fs": "^2.1.1",
     "nock": "^13.2.4",
@@ -71,7 +71,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.6.0",
+    "version": "4.6.2",
     "windowsCI": false
   }
 }

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -427,7 +427,7 @@ t.test('various projectiles', t => {
     }
   }
   t.throws(() => new KidFetcher('foo', {}), {
-    message: `Wrong spec type (tag) for KidFetcher. Supported types: kid`,
+    message: `Wrong spec type (range) for KidFetcher. Supported types: kid`,
   })
   t.end()
 })

--- a/test/git.js
+++ b/test/git.js
@@ -1,12 +1,11 @@
 // set this up first, so we can use 127.0.0.1 as our "hosted git" service
 const httpPort = 18000 + (+process.env.TAP_CHILD_ID || 0)
 const hostedUrl = `http://localhost:${httpPort}`
-const ghi = require('hosted-git-info/lib/git-host-info.js')
+const HostedGit = require('hosted-git-info')
 const gitPort = 12345 + (+process.env.TAP_CHILD_ID || 0)
 
-ghi.byShortcut['localhost:'] = 'localhost'
-ghi.byDomain.localhost = 'localhost'
-ghi.localhost = {
+HostedGit.addHost('localhost', {
+  domain: 'localhost',
   protocols: ['git+https:', 'git+ssh:'],
   tarballtemplate: () => `${hostedUrl}/repo-HEAD.tgz`,
   sshurltemplate: (h) =>
@@ -17,11 +16,10 @@ ghi.localhost = {
     const [, user, project] = url.pathname.split('/')
     return { user, project, committish: url.hash.slice(1) }
   },
-}
+})
 
-ghi.byShortcut['localhosthttps:'] = 'localhosthttps'
-ghi.byDomain['127.0.0.1'] = 'localhosthttps'
-ghi.localhosthttps = {
+HostedGit.addHost('localhosthttps', {
+  domain: '127.0.0.1',
   protocols: ['git+https:', 'git+ssh:', 'git:'],
   httpstemplate: (h) =>
     `git://127.0.0.1:${gitPort}/${h.user}${h.committish ? `#${h.committish}` : ''}`,
@@ -30,11 +28,10 @@ ghi.localhosthttps = {
     const [, user, project] = url.pathname.split('/')
     return { user, project, committish: url.hash.slice(1) }
   },
-}
+})
 
-ghi.byShortcut['localhostssh:'] = 'localhostssh'
-ghi.byDomain.localhostssh = 'localhostssh'
-ghi.localhostssh = {
+HostedGit.addHost('localhostssh', {
+  domain: 'localhostssh',
   protocols: ['git+ssh:'],
   tarballtemplate: () => `${hostedUrl}/repo-HEAD.tgz`,
   sshurltemplate: (h) =>
@@ -47,7 +44,7 @@ ghi.localhostssh = {
     const [, user, project] = url.pathname.split('/')
     return { user, project, committish: url.hash.slice(1) }
   },
-}
+})
 
 const remote = `git://localhost:${gitPort}/repo`
 const remoteHosted = `git://127.0.0.1:${gitPort}/repo`


### PR DESCRIPTION
- fix: handle new npm-package-arg semantics
- chore: bump hosted-git-info from 5.1.0 to 6.0.0
- chore: use ghi.addHost for git tests
- deps: npm-package-arg@10.0.0
- chore: @npmcli/template-oss@4.6.2

Closes #215
Closes #217 
Closes #230 