### PR TITLE
deps: bump @npmcli/installed-package-contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "@npmcli/git": "^4.0.0",
-    "@npmcli/installed-package-contents": "^2.0.0",
+    "@npmcli/installed-package-contents": "^2.0.1",
     "@npmcli/promise-spawn": "^4.0.0",
     "@npmcli/run-script": "^5.0.0",
     "cacache": "^17.0.0",


### PR DESCRIPTION
Bump `@npmcli/installed-package-contents` minimum version to `2.0.1` to ensure the broken `2.0.0` is not installed.

## References:

Related to: https://github.com/npm/installed-package-contents/pull/26

Fixes #231