### PR TITLE
Respect ignoreScripts config when running `npm pack` / `npm publish`

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -36,6 +36,10 @@ class DirFetcher extends Fetcher {
         return
       }
 
+      if (this.opts.ignoreScripts) {
+        return
+      }
+
       // we *only* run prepare.
       // pre/post-pack is run by the npm CLI for publish and pack,
       // but this function is *also* run when installing git deps

--- a/tap-snapshots/test/dir.js.test.cjs
+++ b/tap-snapshots/test/dir.js.test.cjs
@@ -378,3 +378,68 @@ Object {
   },
 }
 `
+
+exports[`test/dir.js TAP with prepare script and ignoreScripts > extract 1`] = `
+Object {
+  "from": "file:test/fixtures/prepare-script",
+  "integrity": "sha512-sSZO46pax+NDC9SFcxOW/m9z1x1OLLtiV9XpZtfaajkdrn/2qo/7gDQ78RhdKQJnDzQxxLxX98B+oCRiHKVybA==",
+  "resolved": "\${CWD}/test/fixtures/prepare-script",
+}
+`
+
+exports[`test/dir.js TAP with prepare script and ignoreScripts > file list 1`] = `
+Array [
+  "package.json",
+  "prepare.js",
+]
+`
+
+exports[`test/dir.js TAP with prepare script and ignoreScripts > manifest 1`] = `
+Object {
+  "_from": "file:test/fixtures/prepare-script",
+  "_id": "git-prepare-script@1.0.0",
+  "_integrity": null,
+  "_resolved": "\${CWD}/test/fixtures/prepare-script",
+  "devDependencies": Object {
+    "abbrev": "^1.1.1",
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "name": "git-prepare-script",
+  "scripts": Object {
+    "prepare": "node prepare.js",
+  },
+  "version": "1.0.0",
+}
+`
+
+exports[`test/dir.js TAP with prepare script and ignoreScripts > packument 1`] = `
+Object {
+  "dist-tags": Object {
+    "latest": "1.0.0",
+  },
+  "name": "git-prepare-script",
+  "versions": Object {
+    "1.0.0": Object {
+      "_from": "file:test/fixtures/prepare-script",
+      "_id": "git-prepare-script@1.0.0",
+      "_integrity": null,
+      "_resolved": "\${CWD}/test/fixtures/prepare-script",
+      "devDependencies": Object {
+        "abbrev": "^1.1.1",
+      },
+      "dist": Object {
+        "integrity": null,
+        "tarball": "file:\${CWD}/test/fixtures/prepare-script",
+      },
+      "license": "ISC",
+      "main": "index.js",
+      "name": "git-prepare-script",
+      "scripts": Object {
+        "prepare": "node prepare.js",
+      },
+      "version": "1.0.0",
+    },
+  },
+}
+`

--- a/test/dir.js
+++ b/test/dir.js
@@ -52,6 +52,8 @@ const prepare = resolve(__dirname, 'fixtures/prepare-script')
 const preparespec = `file:${relative(process.cwd(), prepare)}`
 
 t.test('with prepare script', async t => {
+  // ensure clean fixtures folder - remove file that should get generated
+  fs.rmSync(prepare + '/index.js', { force: true })
   RUNS.length = 0
   const f = new DirFetcher(preparespec, { tree: await loadActual(prepare) })
   t.resolveMatchSnapshot(f.packument(), 'packument')
@@ -64,6 +66,18 @@ t.test('with prepare script', async t => {
       stdio: 'pipe',
       banner: false,
     }, 'should run in background'))
+})
+
+t.test('with prepare script and ignoreScripts', async t => {
+  // ensure clean fixtures folder - remove file that should get generated
+  fs.rmSync(prepare + '/index.js', { force: true })
+  RUNS.length = 0
+  const f = new DirFetcher(preparespec, { tree: await loadActual(prepare), ignoreScripts: true })
+  t.resolveMatchSnapshot(f.packument(), 'packument')
+  t.resolveMatchSnapshot(f.manifest(), 'manifest')
+  return t.resolveMatchSnapshot(f.extract(me + '/prepare'), 'extract')
+    .then(() => t.matchSnapshot(fs.readdirSync(me + '/prepare').sort(), 'file list'))
+    .then(() => t.equal(RUNS.length, 0, 'should not execute the script'))
 })
 
 t.test('responds to foregroundScripts: true', async t => {


### PR DESCRIPTION
This should address https://github.com/npm/cli/issues/3707, although now that I'm re-reading https://github.com/npm/cli/issues/3300, I wonder what is the actual intended behavior? It seems arborist is also keen to run `prepare` regardless of the user setting: https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/arborist/rebuild.js#L180-L182 (while the other scripts it runs above/below do respect the setting).

TBH, my gut feeling is that the `--ignore-scripts` should take precedence over anything else. I know there's an RFC for [command specific config](https://github.com/npm/rfcs/pull/566), but we're probably a long way from there and running scripts when people explicitly disable them is a security issue too that needs to be communicated as such at the very least.

If it's the case that `prepare` takes precedence over `--ignore-scripts`, then there's probably a need for `--ignore-scripts-but-we-really-mean-it-this-time`...