### PR TITLE
deps: sigstore@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "promise-retry": "^2.0.1",
     "read-package-json": "^6.0.0",
     "read-package-json-fast": "^3.0.0",
-    "sigstore": "^1.1.0",
+    "sigstore": "^1.3.0",
     "ssri": "^10.0.0",
     "tar": "^6.1.11"
   },

--- a/test/registry.js
+++ b/test/registry.js
@@ -542,7 +542,7 @@ t.test('verifyAttestations errors when tuf update fails', async t => {
     'utf8'
   )
 
-  tnock(t, 'https://sigstore-tuf-root.storage.googleapis.com')
+  tnock(t, 'https://tuf-repo-cdn.sigstore.dev')
     .get(/./) // match any path
     .reply(404)
 


### PR DESCRIPTION
<!-- What / Why -->
Updates `sigstore` to version 1.3.0.

This sigstore release updates the mirror URL which is used to connect to the Sigstore TUF repository. Since we're nock'ing that URL in one of the tests here, we need make an explicit version bump and update the URL in the test.



