### PR TITLE
feat: configurable TUF cache dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ resolved, and other properties, as they are determined.
 * `verifyAttestations` A boolean that will make pacote verify Sigstore
     attestations, if present. There must be a configured `_keys` entry in the
     config that is scoped to the registry the manifest is being fetched from.
+* `tufCache` Where to store metadata/target files when retrieving the package
+  attestation key material via TUF. Defaults to the same cache directory that
+  npm will use by default, based on platform and environment.
 
 ### Advanced API
 

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -61,7 +61,8 @@ class FetcherBase {
     // by adding/modifying the integrity value.
     this.opts = { ...opts }
 
-    this.cache = opts.cache || cacheDir()
+    this.cache = opts.cache || cacheDir().cacache
+    this.tufCache = opts.tufCache || cacheDir().tufcache
     this.resolved = opts.resolved || null
 
     // default to caching/verifying with sha512, that's what we usually have

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -295,7 +295,10 @@ class RegistryFetcher extends Fetcher {
               //
               // Publish attestations are signed with a keyid so we need to
               // specify a public key from the keys endpoint: `registry-host.tld/-/npm/v1/keys`
-              const options = { keySelector: publicKey ? () => publicKey.pemkey : undefined }
+              const options = {
+                tufCachePath: this.tufCache,
+                keySelector: publicKey ? () => publicKey.pemkey : undefined,
+              }
               await sigstore.verify(bundle, null, options)
             } catch (e) {
               throw Object.assign(new Error(

--- a/lib/util/cache-dir.js
+++ b/lib/util/cache-dir.js
@@ -8,5 +8,8 @@ module.exports = (fakePlatform = false) => {
   const platform = fakePlatform || process.platform
   const cacheExtra = platform === 'win32' ? 'npm-cache' : '.npm'
   const cacheRoot = (platform === 'win32' && process.env.LOCALAPPDATA) || home
-  return resolve(cacheRoot, cacheExtra, '_cacache')
+  return {
+    cacache: resolve(cacheRoot, cacheExtra, '_cacache'),
+    tufcache: resolve(cacheRoot, cacheExtra, '_tuf'),
+  }
 }

--- a/test/util/cache-dir.js
+++ b/test/util/cache-dir.js
@@ -18,15 +18,21 @@ const cacheDir = require('../../lib/util/cache-dir.js')
 // on all platforms.
 t.ok(cacheDir(), 'a cache dir is ok')
 
-t.equal(cacheDir(posix), '/home/isaacs/.npm/_cacache')
-t.equal(cacheDir(windows), '/home/isaacs/npm-cache/_cacache')
+t.equal(cacheDir(posix).cacache, '/home/isaacs/.npm/_cacache')
+t.equal(cacheDir(windows).cacache, '/home/isaacs/npm-cache/_cacache')
+t.equal(cacheDir(posix).tufcache, '/home/isaacs/.npm/_tuf')
+t.equal(cacheDir(windows).tufcache, '/home/isaacs/npm-cache/_tuf')
 
 os.homedir = () => null
-t.equal(cacheDir(posix), '/tmp/npm-69420/.npm/_cacache')
-t.equal(cacheDir(windows), '/tmp/npm-69420/npm-cache/_cacache')
+t.equal(cacheDir(posix).cacache, '/tmp/npm-69420/.npm/_cacache')
+t.equal(cacheDir(windows).cacache, '/tmp/npm-69420/npm-cache/_cacache')
+t.equal(cacheDir(posix).tufcache, '/tmp/npm-69420/.npm/_tuf')
+t.equal(cacheDir(windows).tufcache, '/tmp/npm-69420/npm-cache/_tuf')
 
 process.env.LOCALAPPDATA = '/%LOCALAPPDATA%'
-t.equal(cacheDir(windows), '/%LOCALAPPDATA%/npm-cache/_cacache')
+t.equal(cacheDir(windows).cacache, '/%LOCALAPPDATA%/npm-cache/_cacache')
+t.equal(cacheDir(windows).tufcache, '/%LOCALAPPDATA%/npm-cache/_tuf')
 
 process.getuid = null
-t.equal(cacheDir(posix), `/tmp/npm-${process.pid}/.npm/_cacache`)
+t.equal(cacheDir(posix).cacache, `/tmp/npm-${process.pid}/.npm/_cacache`)
+t.equal(cacheDir(posix).tufcache, `/tmp/npm-${process.pid}/.npm/_tuf`)


### PR DESCRIPTION
Adds support for a new `tufCache` parameter that allows us to synchronize the TUF cache path with the npm CLI (see https://github.com/npm/cli/pull/6418). The TUF cache is passed to the `sigstore` library and is used when downloading the key material necessary to verify package provenance attestations.

Also updates the `cache-dir` module so that the TUF cache can be defaulted in the same way as cacache.