### PR TITLE
Fix audit signatures for expired keys

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -17,6 +17,15 @@ const fullDoc = 'application/json'
 const fetch = require('npm-registry-fetch')
 
 const _headers = Symbol('_headers')
+
+// NOTE: Workaround for very old packages that don't have a publish time set.
+// This fallback date is set to after all packages in the npm registry where
+// resigned with the new keys (started in February 2022) and "npm audit
+// signatures" cmd was introduced in npm v8.14.0 (Jul 13, 2022) and pacote
+// v13.4.0 (May 17, 2022) as there should be no keys that expire before this
+// time. This should also be true across any third-party registries.
+const NPM_MISSING_PUBLISH_TIME_FALLBACK_DATE = Date.parse('2022-07-14T00:00:00.000Z')
+
 class RegistryFetcher extends Fetcher {
   constructor (spec, opts) {
     super(spec, opts)
@@ -171,8 +180,11 @@ class RegistryFetcher extends Fetcher {
                   'but no corresponding public key can be found'
               ), { code: 'EMISSINGSIGNATUREKEY' })
             }
+
+            const publishTime = mani._time ?
+              Date.parse(mani._time) : NPM_MISSING_PUBLISH_TIME_FALLBACK_DATE
             const validPublicKey =
-              !publicKey.expires || (Date.parse(publicKey.expires) > Date.now())
+              !publicKey.expires || (Date.parse(publicKey.expires) > publishTime)
             if (!validPublicKey) {
               throw Object.assign(new Error(
                   `${mani._id} has a registry signature with keyid: ${signature.keyid} ` +
@@ -254,8 +266,10 @@ class RegistryFetcher extends Fetcher {
                 ), { code: 'EMISSINGSIGNATUREKEY' })
               }
 
+              const publishTime = mani._time ?
+                Date.parse(mani._time) : NPM_MISSING_PUBLISH_TIME_FALLBACK_DATE
               const validPublicKey =
-                !publicKey.expires || (Date.parse(publicKey.expires) > Date.now())
+                !publicKey.expires || (Date.parse(publicKey.expires) > publishTime)
               if (!validPublicKey) {
                 throw Object.assign(new Error(
                   `${mani._id} has attestations with keyid: ${keyid} ` +


### PR DESCRIPTION
The current implementation of verifySignatures and verifyAttestations assumes the verification keys never expire as its checking if expiry is in the past, this means we can never roll these keys and verify old signatures that where signed with a still valid signing key.

Kudos to @bdehamer for spotting this bug.

This changes the key selector to allow keys that where valid before the package was published so we can roll new keys in future.

There's an accompanying change required in npm-pick-manifest to expose the publish time. If this is not set I opted to use a fallback date, this isn't pretty but seems better than ignoring packages that don't have created at time? Open to suggeststions here!

TODO:
- Introduce `_time`: https://github.com/npm/npm-pick-manifest/pull/87
- Add a test for very old packages that don't have `time` in packument
