### PR TITLE
fix: don't use FileFetcher.manifest() for git pkgs

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -309,15 +309,13 @@ class GitFetcher extends Fetcher {
       return Promise.resolve(this.package)
     }
 
-    return this.spec.hosted && this.resolved
-      ? FileFetcher.prototype.manifest.apply(this)
-      : this[_clone](dir =>
-        this[_readPackageJson](dir + '/package.json')
-          .then(mani => this.package = {
-            ...mani,
-            _resolved: this.resolved,
-            _from: this.from,
-          }))
+    return this[_clone](dir =>
+      this[_readPackageJson](dir + '/package.json')
+        .then(mani => this.package = {
+          ...mani,
+          _resolved: this.resolved,
+          _from: this.from,
+        }))
   }
 
   packument () {

--- a/test/git.js
+++ b/test/git.js
@@ -506,7 +506,7 @@ t.test('extract from tarball from hosted git service', async t => {
           scripts: { prepare: 'node prepare.js', test: 'node index.js' },
           files: ['index.js'],
           _id: 'repo@1.0.0',
-          _integrity: /^sha512-/,
+          _integrity: undefined,
           _resolved: `${remoteHosted}#${REPO_HEAD}`,
         })
         const p = await g.packument()
@@ -524,7 +524,7 @@ t.test('extract from tarball from hosted git service', async t => {
               scripts: { prepare: 'node prepare.js', test: 'node index.js' },
               files: ['index.js'],
               _id: 'repo@1.0.0',
-              _integrity: /^sha512-/,
+              _integrity: undefined,
               _resolved: `${remoteHosted}#${REPO_HEAD}`,
               dist: {},
             },
@@ -539,6 +539,19 @@ t.test('extract from tarball from hosted git service', async t => {
       t.test('without repo@on the spec', runTest(''))
     })
   }
+})
+
+t.test('can get manifest without arborist constructor', async t => {
+  const spec = `localhost:repo/x#${REPO_HEAD}`
+  const noArbOpts = { ...opts, Arborist: null }
+  const g = new GitFetcher(spec, noArbOpts)
+  const m = await g.manifest()
+  t.match(m, {
+    name: 'repo',
+    version: '1.0.0',
+    _integrity: undefined,
+    _resolved: `${remoteHosted}#${REPO_HEAD}`,
+  })
 })
 
 t.test('include auth with hosted https when provided', async t => {


### PR DESCRIPTION
To get the manifest for a hosted, resolved git package, pacote uses FileFetcher.manifest. FileFetcher.manifest calls extract(), which calls _tarballFromResolved.

This means getting the manifest involves nearly a complete pack operation, including 'npm install', the 'prepare' script etc. It also means getting the manifest requires an Arborist constructor (causes npm/cli#6723).

Remove the special handling of hosted, resolved git packages, handle all git packages the same way: clone the repo (or get the tarball from a hosted git server) and read the package.json.

The effects for hosted, resolved git packages:

- getting the manifest no longer involves packing the tarball
- getting the manifest no longer requires an Arborist constructor
- the manifest no longer includes an _integrity (same as un-hosted or un-resolved git packages)