### PR TITLE
deps: bump sigstore from 2.0.0 to 2.2.0

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -321,6 +321,7 @@ class RegistryFetcher extends Fetcher {
               // specify a public key from the keys endpoint: `registry-host.tld/-/npm/v1/keys`
               const options = {
                 tufCachePath: this.tufCache,
+                tufForceCache: true,
                 keySelector: publicKey ? () => publicKey.pemkey : undefined,
               }
               await sigstore.verify(bundle, options)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "promise-retry": "^2.0.1",
     "read-package-json": "^7.0.0",
     "read-package-json-fast": "^3.0.0",
-    "sigstore": "^2.0.0",
+    "sigstore": "^2.2.0",
     "ssri": "^10.0.0",
     "tar": "^6.1.11"
   },


### PR DESCRIPTION
Update `sigstore` to version 2.2.0.

Leverages the new `tufForceCache` option in the sigstore `verify` function to make better use of the local TUF cache. Previously, the TUF cache would be refreshed with each invocation -- now the TUF cache will only be refreshed if the metadata files contained therein are expired. 

Eliminates one test case which is no longer relevant given the use of the `tufForceCache` option.
