### PR TITLE
deps: bump sigstore from 2.2.0 to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "promise-retry": "^2.0.1",
     "read-package-json": "^7.0.0",
     "read-package-json-fast": "^3.0.0",
-    "sigstore": "^2.2.0",
+    "sigstore": "^2.2.2",
     "ssri": "^10.0.0",
     "tar": "^6.1.11"
   },


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Updates `sigstore` to version 2.2.2 which includes support for verifying Sigstore bundles using the [v0.3 spec](https://github.com/sigstore/protobuf-specs/pull/213).

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
