### PR TITLE
fix: don't strip underscore attributes in .manifest()

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -127,11 +127,12 @@ class RegistryFetcher extends Fetcher {
     }
 
     const packument = await this.packument()
+    const steps = PackageJson.normalizeSteps.filter(s => s !== '_attributes')
     const mani = await new PackageJson().fromContent(pickManifest(packument, this.spec.fetchSpec, {
       ...this.opts,
       defaultTag: this.defaultTag,
       before: this.before,
-    })).normalize().then(p => p.content)
+    })).normalize({ steps }).then(p => p.content)
 
     /* XXX add ETARGET and E403 revalidation of cached packuments here */
 

--- a/test/registry.js
+++ b/test/registry.js
@@ -1267,6 +1267,7 @@ t.test('option replaceRegistryHost', rhTest => {
         dist: {
           tarball: 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz',
         },
+        _test: true,
       },
     },
   })
@@ -1291,6 +1292,7 @@ t.test('option replaceRegistryHost', rhTest => {
     const manifest = await fetcher.manifest()
     ct.equal(manifest.dist.tarball, 'https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz')
     const tarball = await fetcher.tarball()
+    ct.equal(manifest._test, true, 'Underscores are preserved')
     ct.match(tarball, abbrevTGZ)
   })
 


### PR DESCRIPTION
This was a quirk of how we were using read-package-json-fast.
Only its package.json file parsing was doing that step
