### PR TITLE
fix: wait for size event from body for contentLength

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -9,6 +9,8 @@ const ssri = require('ssri')
 const crypto = require('crypto')
 const npa = require('npm-package-arg')
 const sigstore = require('sigstore')
+const { isStream } = require('minipass')
+const { once } = require('node:stream')
 
 // Corgis are cute. 🐕🐶
 const corgiDoc = 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
@@ -96,7 +98,11 @@ class RegistryFetcher extends Fetcher {
         integrity: null,
       })
       const packument = await res.json()
-      packument._contentLength = +res.headers.get('content-length')
+      let contentLength = res.headers.get('content-length') ?? null
+      if (contentLength === null && isStream(res.body)) {
+        contentLength = await once(res.body, 'size').then(r => r[0])
+      }
+      packument._contentLength = +contentLength
       if (this.packumentCache) {
         this.packumentCache.set(this.packumentUrl, packument)
       }

--- a/test/registry.js
+++ b/test/registry.js
@@ -1188,6 +1188,11 @@ t.test('a manifest that lacks integrity', async t => {
   t.equal(await f.packument(), await f2.packument(), 'serve cached packument')
 })
 
+t.test('packument has contentLength', async t => {
+  const f = new RegistryFetcher('underscore', { registry, cache })
+  t.match(await f.packument(), { _contentLength: 40966 }, 'got contentLength from body')
+})
+
 t.test('packument that has been cached', async t => {
   const packumentUrl = `${registry}asdf`
   const packument = {


### PR DESCRIPTION
By default the `Accept-Encoding` request header is set to `gzip,deflate` which makes it so we don't get back a `Content-Length` response header from the registry. But `npm-registry-fetch` sets up a `size` event on the response body that we can wait for before continuing if we don't get a `Content-Length` header.

This fixes the content length issue in #7463 for me when testing locally, but I need to run some more CLI tests with this linked to see if there are any adverse effects.