### PR TITLE
fix: dont set _contentLength if not in headers

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -95,7 +95,10 @@ class RegistryFetcher extends Fetcher {
         integrity: null,
       })
       const packument = await res.json()
-      packument._contentLength = +res.headers.get('content-length')
+      const contentLength = res.headers.get('content-length')
+      if (contentLength) {
+        packument._contentLength = Number(contentLength)
+      }
       this.packumentCache?.set(this.packumentUrl, packument)
       return packument
     } catch (err) {

--- a/test/registry.js
+++ b/test/registry.js
@@ -1341,3 +1341,9 @@ t.test('option replaceRegistryHost', rhTest => {
 
   rhTest.end()
 })
+
+t.test('packument contentLength from registry', async t => {
+  const f = new RegistryFetcher('underscore', { registry, cache })
+  const p = await f.packument()
+  t.equal(p._contentLength, undefined, 'content length is undefined from registry requests')
+})


### PR DESCRIPTION
The opposite of #366. This is not a change in behavior but makes it clear that we don't expect _contentLength to be set when the request is coming directly from the registry when there is no cache.
