### PR TITLE
fix: prepare script respects scriptshell config

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -39,6 +39,8 @@ class DirFetcher extends Fetcher {
       const stdio = this.opts.foregroundScripts ? 'inherit' : 'pipe'
 
       return runScript({
+        // this || undefined is because runScript will be unhappy with the default null value
+        scriptShell: this.opts.scriptShell || undefined,
         pkg: mani,
         event: 'prepare',
         path: this.resolved,

--- a/tap-snapshots/test/dir.js.test.cjs
+++ b/tap-snapshots/test/dir.js.test.cjs
@@ -312,3 +312,69 @@ Object {
   },
 }
 `
+
+exports[`test/dir.js TAP with prepare script with scriptshell configuration > extract 1`] = `
+Object {
+  "from": "file:test/fixtures/prepare-script",
+  "integrity": "{integrity}",
+  "resolved": "\${CWD}/test/fixtures/prepare-script",
+}
+`
+
+exports[`test/dir.js TAP with prepare script with scriptshell configuration > file list 1`] = `
+Array [
+  "index.js",
+  "package.json",
+  "prepare.js",
+]
+`
+
+exports[`test/dir.js TAP with prepare script with scriptshell configuration > manifest 1`] = `
+Object {
+  "_from": "file:test/fixtures/prepare-script",
+  "_id": "git-prepare-script@1.0.0",
+  "_integrity": null,
+  "_resolved": "\${CWD}/test/fixtures/prepare-script",
+  "devDependencies": Object {
+    "abbrev": "^1.1.1",
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "name": "git-prepare-script",
+  "scripts": Object {
+    "prepare": "node prepare.js",
+  },
+  "version": "1.0.0",
+}
+`
+
+exports[`test/dir.js TAP with prepare script with scriptshell configuration > packument 1`] = `
+Object {
+  "dist-tags": Object {
+    "latest": "1.0.0",
+  },
+  "name": "git-prepare-script",
+  "versions": Object {
+    "1.0.0": Object {
+      "_from": "file:test/fixtures/prepare-script",
+      "_id": "git-prepare-script@1.0.0",
+      "_integrity": null,
+      "_resolved": "\${CWD}/test/fixtures/prepare-script",
+      "devDependencies": Object {
+        "abbrev": "^1.1.1",
+      },
+      "dist": Object {
+        "integrity": null,
+        "tarball": "file:\${CWD}/test/fixtures/prepare-script",
+      },
+      "license": "ISC",
+      "main": "index.js",
+      "name": "git-prepare-script",
+      "scripts": Object {
+        "prepare": "node prepare.js",
+      },
+      "version": "1.0.0",
+    },
+  },
+}
+`

--- a/test/dir.js
+++ b/test/dir.js
@@ -66,6 +66,22 @@ t.test('with prepare script', async t => {
     }, 'should run in background'))
 })
 
+t.test('with prepare script with scriptshell configuration', async t => {
+  RUNS.length = 0
+  const f = new DirFetcher(preparespec, { tree: await loadActual(prepare), scriptShell: 'sh' })
+  t.resolveMatchSnapshot(f.packument(), 'packument')
+  t.resolveMatchSnapshot(f.manifest(), 'manifest')
+  const index = me + '/prepare/index.js'
+  return t.resolveMatchSnapshot(f.extract(me + '/prepare'), 'extract')
+    .then(() => t.spawn(process.execPath, [index], 'test prepared result'))
+    .then(() => t.matchSnapshot(fs.readdirSync(me + '/prepare').sort(), 'file list'))
+    .then(() => t.match(RUNS,
+      [{
+        stdio: 'pipe',
+        scriptShell: 'sh',
+      }], 'should run in background and use scriptshell configuration'))
+})
+
 t.test('responds to foregroundScripts: true', async t => {
   RUNS.length = 0
   const opt = { foregroundScripts: true, tree: await loadActual(prepare) }


### PR DESCRIPTION
Prepare script respects scriptshell config if passed matching behaviour of `npm run <script>` 

fixes: https://github.com/npm/cli/issues/7723