### PR TITLE
chore: bump hosted-git-info ^7.0.0 to ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@npmcli/arborist": "^7.1.0",
     "@npmcli/eslint-config": "^5.0.0",
     "@npmcli/template-oss": "4.23.3",
-    "hosted-git-info": "^7.0.0",
+    "hosted-git-info": "^8.0.0",
     "mutate-fs": "^2.1.1",
     "nock": "^13.2.4",
     "npm-registry-mock": "^1.3.2",


### PR DESCRIPTION
Bumping to fix tests in https://github.com/npm/pacote/pull/392 reguarding custom localhost protocol