### PR TITLE
chore: log tarball retrieval from cache

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -188,6 +188,9 @@ class FetcherBase {
   // private
   // Note: cacache will raise a EINTEGRITY error if the integrity doesn't match
   #tarballFromCache () {
+    log.silly('tarball', `getting data for ${
+      this.spec
+    } from cache`)
     return cacache.get.stream.byDigest(this.cache, this.integrity, this.opts)
   }
 


### PR DESCRIPTION
If tarballs are cached, the npm install log contains no information on where it got the tarball from. This helps troubleshoot issues with caching and `preferOnline/preferOffline`, for example.


