### PR TITLE
fix: engine strict config issue on npm install

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -131,6 +131,7 @@ class RegistryFetcher extends Fetcher {
       ...this.opts,
       defaultTag: this.defaultTag,
       before: this.before,
+      engineStrict: this.opts.engineStrict,
     })).normalize({ steps }).then(p => p.content)
 
     /* XXX add ETARGET and E403 revalidation of cached packuments here */


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The fix addresses an issue where the engine-strict flag is not enforced during the version resolution phase in npm. When engine-strict is enabled, npm should only install package versions that are compatible with the current Node.js version, as specified in the package's engines field. However, prior to this fix, npm did not consider the engines.node field during version resolution, potentially leading to the installation of incompatible package versions.

By passing engineStrict, we ensure npm-pick-manifest filters out package versions that are incompatible with the current Node.js version when engineStrict is enabled.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
