### PR TITLE
deps: bump sigstore from 2.2.0 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "npm-registry-fetch": "^18.0.0",
     "proc-log": "^5.0.0",
     "promise-retry": "^2.0.1",
-    "sigstore": "^2.2.0",
+    "sigstore": "^3.0.0",
     "ssri": "^12.0.0",
     "tar": "^6.1.11"
   },


### PR DESCRIPTION
Updates `sigstore` to version 3.0.0 which removes support for node 16.

