### PR TITLE
fix!: honors `ignoreScripts` option to prevent `prepare` lifecycle script

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -32,6 +32,9 @@ class DirFetcher extends Fetcher {
       if (!mani.scripts || !mani.scripts.prepare) {
         return
       }
+      if (this.opts.ignoreScripts) {
+        return
+      }
 
       // we *only* run prepare.
       // pre/post-pack is run by the npm CLI for publish and pack,

--- a/test/dir.js
+++ b/test/dir.js
@@ -164,3 +164,29 @@ t.test('fails without a tree or constructor', async t => {
   const f = new DirFetcher(abbrevspec, {})
   t.rejects(() => f.extract(me + '/prepare'))
 })
+
+t.test('with prepare script and ignoreScripts true', async t => {
+  let shouldNotBePopulated = false
+
+  const DirFetcherIsolate = t.mock('../lib/dir.js', {
+    '@npmcli/run-script': () => {
+      shouldNotBePopulated = true
+    },
+  })
+
+  const dir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'meow',
+      version: '1.0.0',
+      scripts: {
+        prepare: 'noop',
+      },
+    }),
+  })
+  const f = new DirFetcherIsolate(`file:${relative(process.cwd(), dir)}`, {
+    tree: await loadActual(dir),
+    ignoreScripts: true,
+  })
+  await f.extract(me + '/prepare-ignore')
+  t.ok(!shouldNotBePopulated)
+})

--- a/test/fixtures/prepare-ignore/package.json
+++ b/test/fixtures/prepare-ignore/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "prepare-ignore",
+    "version": "1.0.0",
+    "scripts": {
+        "prepare": "noop"
+    }
+}

--- a/test/fixtures/prepare-ignore/package.json
+++ b/test/fixtures/prepare-ignore/package.json
@@ -1,7 +1,0 @@
-{
-    "name": "prepare-ignore",
-    "version": "1.0.0",
-    "scripts": {
-        "prepare": "noop"
-    }
-}


### PR DESCRIPTION
Adds ignoreScript option support to prevent execution of prepare lifecycle script.

from: https://github.com/npm/cli/issues/7211
part of: https://github.com/npm/statusboard/issues/898

Currently the tests don't run locally for some reason, i'm thinking because they spin up a https://localhost server. It runs in docker.

I used this to isolate the build and test locally:

```bash
docker-node() { docker run --rm -v "$(pwd)":/app -w /app -e "TAP_SNAPSHOT=$TAP_SNAPSHOT" node:22 "$@"; }

docker-node npm test
docker-node npm test -- ./test/dir.js
```