### PR TITLE
deps: replace node builtin rmSync with rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mutate-fs": "^2.1.1",
     "nock": "^13.2.4",
     "npm-registry-mock": "^1.3.2",
+    "rimraf": "^6.0.1",
     "tap": "^16.0.1"
   },
   "files": [

--- a/test/git.js
+++ b/test/git.js
@@ -221,6 +221,7 @@ t.test('setup', { bail: true }, t => {
     }
     daemon.stderr.on('data', onDaemonData)
     // only clean up the dir once the daemon is banished
+    // do NOT replace this with node's internal rmSync.  It generates EBUSY errors in windows.
     daemon.on('close', () => rimraf.sync(me))
   })
 

--- a/test/git.js
+++ b/test/git.js
@@ -3,12 +3,12 @@ const fs = require('node:fs')
 const http = require('node:http')
 const { dirname, basename, resolve } = require('node:path')
 const { mkdir } = require('node:fs/promises')
-const { rmSync } = require('node:fs')
 const { spawn } = require('node:child_process')
 const Arborist = require('@npmcli/arborist')
 const HostedGit = require('hosted-git-info')
 const npa = require('npm-package-arg')
 const spawnGit = require('@npmcli/git').spawn
+const rimraf = require('rimraf')
 const tar = require('tar')
 const spawnNpm = require('../lib/util/npm.js')
 const GitFetcher = require('../lib/git.js')
@@ -221,7 +221,7 @@ t.test('setup', { bail: true }, t => {
     }
     daemon.stderr.on('data', onDaemonData)
     // only clean up the dir once the daemon is banished
-    daemon.on('close', () => rmSync(me, { recursive: true, force: true }))
+    daemon.on('close', () => rimraf.sync(me))
   })
 
   t.test('create a repo with a submodule', () => {


### PR DESCRIPTION
This avoids the EBUSY issue during "spawn daemon" test mentioned in https://github.com/npm/pacote/pull/408