### PR TITLE
deps!: npm-packlist@10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fs-minipass": "^3.0.0",
     "minipass": "^7.0.2",
     "npm-package-arg": "^12.0.0",
-    "npm-packlist": "^9.0.0",
+    "npm-packlist": "^10.0.0",
     "npm-pick-manifest": "^10.0.0",
     "npm-registry-fetch": "^18.0.0",
     "proc-log": "^5.0.0",


### PR DESCRIPTION
BREAKING CHANGE: `bun.lockb` files are now included in the strict ignore list during packing
