### PR TITLE
chore: tests should not inherit --ignore-scripts flag from `npm run t…

### DIFF
--- a/test/git.js
+++ b/test/git.js
@@ -1,3 +1,6 @@
+// `npm test --ignore-scripts` overrides any local options, so we need to remove it from the env
+delete process.env.npm_config_ignore_scripts
+
 const t = require('tap')
 const fs = require('node:fs')
 const http = require('node:http')


### PR DESCRIPTION
CI is currently failing in `main`. This aims to resolve it. It was tricky to figure out the difference because I don't usually run `npm test` with `--ignore-scripts` locally.