### PR TITLE
fix!: do not switch to git+ssh for https repository links

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -19,7 +19,7 @@ const hashre = /^[a-f0-9]{40}$/
 // otherwise, prefer ssh if available (more secure).
 // We have to add the git+ back because npa suppresses it.
 const repoUrl = (h, opts) =>
-  h.sshurl && !(h.https && h.auth) && addGitPlus(h.sshurl(opts)) ||
+  h.sshurl && !(h.https && (h.auth || h.default === 'https')) && addGitPlus(h.sshurl(opts)) ||
   h.https && addGitPlus(h.https(opts))
 
 // add git+ to the url, but only one time.

--- a/lib/util/add-git-sha.js
+++ b/lib/util/add-git-sha.js
@@ -3,7 +3,7 @@ const addGitSha = (spec, sha) => {
   if (spec.hosted) {
     const h = spec.hosted
     const opt = { noCommittish: true }
-    const base = h.https && h.auth ? h.https(opt) : h.shortcut(opt)
+    const base = h.https && (h.auth || h.default === 'https') ? h.https(opt) : h.shortcut(opt)
 
     return `${base}#${sha}`
   } else {

--- a/test/git.js
+++ b/test/git.js
@@ -670,13 +670,14 @@ t.test('repoUrl function', { skip: isWindows && 'posix only' }, async t => {
   const { hosted: ssh } = npa(`git+ssh://git@github.com/${proj}`)
   const { hosted: git } = npa(`git://github.com/${proj}`)
   const { repoUrl } = GitFetcher
-  const expectNoAuth = `git+ssh://git@github.com/${proj}`
+  const expectNoAuthSsh = `git+ssh://git@github.com/${proj}`
+  const expectNoAuthHttps = `git+https://github.com/${proj}`
   const expectAuth = `git+https://user:pass@github.com/${proj}`
-  t.match(repoUrl(shortcut), expectNoAuth)
+  t.match(repoUrl(shortcut), expectNoAuthSsh)
   t.match(repoUrl(hasAuth), expectAuth)
-  t.match(repoUrl(noAuth), expectNoAuth)
-  t.match(repoUrl(ssh), expectNoAuth)
-  t.match(repoUrl(git), expectNoAuth)
+  t.match(repoUrl(noAuth), expectNoAuthHttps)
+  t.match(repoUrl(ssh), expectNoAuthSsh)
+  t.match(repoUrl(git), expectNoAuthSsh)
 })
 
 t.test('handle it when prepared git deps depend on each other', { skip: isWindows && 'posix only' },

--- a/test/util/add-git-sha.js
+++ b/test/util/add-git-sha.js
@@ -28,9 +28,9 @@ const cases = [
     'sha',
     'https://git@github.com/user/repo.git#sha'],
   // github https no auth
-  ['git+https://github.com/user/repo', 'sha', 'github:user/repo#sha'],
-  ['git+https://github.com/user/repo#othersha', 'sha', 'github:user/repo#sha'],
-  ['git+https://github.com/user/repo#othersha#otherothersha', 'sha', 'github:user/repo#sha'],
+  ['git+https://github.com/user/repo', 'sha', 'https://github.com/user/repo.git#sha'],
+  ['git+https://github.com/user/repo#othersha', 'sha', 'https://github.com/user/repo.git#sha'],
+  ['git+https://github.com/user/repo#othersha#otherothersha', 'sha', 'https://github.com/user/repo.git#sha'],
   // github ssh
   ['git+ssh://git@github.com/user/repo', 'sha', 'github:user/repo#sha'],
   ['git+ssh://git@github.com/user/repo#othersha', 'sha', 'github:user/repo#sha'],


### PR DESCRIPTION
BREAKING CHANGE: git specs using the `https` or `git+https` protocol now resolve to `git+https` URLs instead of being switched to `git+ssh`. Shortcut specs (e.g. `github:user/repo`, `user/repo`) and `git+ssh`/`git://` specs are unchanged.

When the URL explicitly contains https, do not try to switch to ssh. This change is necessary for [npm][3] to retain the protocol, please see the link and the referenced issues [here][1] and [here][2] reporting problems when using ssh instead of requested https.

[1]: https://github.com/npm/cli/issues/2610
[2]: https://github.com/npm/cli/issues/4305
[3]: https://github.com/npm/cli/pull/8703

## References
Relates to https://github.com/npm/cli/pull/8703
