### PR TITLE
feat: implement gitSubdir according to npa spec

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -245,7 +245,7 @@ class GitFetcher extends Fetcher {
           pkgid: `git:${nameat}${this.resolved}`,
           resolved: this.resolved,
           integrity: null, // it'll always be different, if we have one
-        }).extract(tmp).then(() => handler(tmp), er => {
+        }).extract(tmp).then(() => handler(`${tmp}${this.spec.gitSubdir || ''}`), er => {
           // fall back to ssh download if tarball fails
           if (er.constructor.name.match(/^Http/)) {
             return this.#clone(handler, false)
@@ -263,7 +263,7 @@ class GitFetcher extends Fetcher {
       if (!this.resolved) {
         await this.#addGitSha(sha)
       }
-      return handler(tmp)
+      return handler(`${tmp}${this.spec.gitSubdir || ''}`)
     })
   }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This implements the `gitSubdir` parameter, which is already parsed by npa, finally allowing users of npm to specifiy subdirectories in git dependencies.

The respective parsing logic has already been agreed on and implemented nearly 4 years ago here: https://github.com/npm/npm-package-arg/pull/91. In this PR, the git fetcher is changed to resolve the `gitSubdir` parameter from the spec if found, as suggested by the author in the original npa PR.

## References
Fixes https://github.com/npm/cli/issues/528
Fixes https://github.com/npm/npm/issues/2974
Relates to https://github.com/npm/npm-package-arg/pull/46
Relates to  https://github.com/npm/npm-package-arg/pull/91

Inspired from and crediting https://github.com/sspiff/pacote/commit/8bd54618ee5a240bf4a82f90b852bf52f99363ee, which seems to have been lost after merging the PR at npa.