### PR TITLE
feat: add support for git-256 sha lengths

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -12,7 +12,7 @@ const _ = require('./util/protected.js')
 const addGitSha = require('./util/add-git-sha.js')
 const npm = require('./util/npm.js')
 
-const hashre = /^[a-f0-9]{40}$/
+const hashre = /^[a-f0-9]{40,64}$/
 
 // get the repository url.
 // prefer https if there's auth, since ssh will drop that.

--- a/test/git.js
+++ b/test/git.js
@@ -828,3 +828,13 @@ t.test('gitSubdir extraction', { skip: isWindows && 'posix only' }, async t => {
   t.ok(fs.statSync(`${extract}/index.js`))
   t.ok(fs.statSync(`${extract}/package.json`))
 })
+
+t.test('sha-1 and sha-256', t => {
+  const sha1 = '0d7bd85a85fa2571fa532d2fc842ed099b236ad2'
+  const sha256 = '8e3a9b3579ab330238c06b761e7f1b5dc5b4ac6e5a96da4dd2fb3b7411009df8'
+  const g1 = new GitFetcher(`${remote}#${sha1}`, opts)
+  t.equal(g1.resolvedSha, sha1)
+  const g2 = new GitFetcher(`${remote}#${sha256}`, opts)
+  t.equal(g2.resolvedSha, sha256)
+  t.end()
+})


### PR DESCRIPTION
They are 64 characters long, not 40