### PR TITLE
feat: add allowRegistry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Options object is cloned, and mutated along the way to add integrity, resolved, 
   Possible values and defaults are the same as `allowGit`
 * `allowDirectory` Whether or not to allow data to be fetched from directory specs.
   Possible values and defaults are the same as `allowGit`
+* `allowRegistry` Whether or not to allow data to be fetched from registry specs.  This includes `version`, `range`, `tag`, and `alias`.
 * `_isRoot` Whether or not the package being fetched is in a root context.
   Defaults to `false`,
   For `npm` itself this means a package that is defined in the local project or workspace package.json, or a package that is being fetched for another command like `npm view`.  This informs the `allowX` options to let them know the context of the current request.

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -502,6 +502,7 @@ FetcherBase.get = (rawSpec, opts = {}) => {
     case 'range':
     case 'tag':
     case 'alias':
+      canUse({ allow: opts.allowRegistry, isRoot: opts._isRoot, allowType: 'registry', spec })
       return new RegistryFetcher(spec.subSpec || spec, opts)
 
     case 'file':

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -542,6 +542,10 @@ t.test('allowX', t => {
     ['allowRemote', 'http://npmjs.org/package'],
     ['allowFile', './local.tgz'],
     ['allowDirectory', './local/dir'],
+    ['allowRegistry', '@npmcli/test'],
+    ['allowRegistry', '@npmcli/test@1.0.0'],
+    ['allowRegistry', '@npmcli/test@latest'],
+    ['allowRegistry', 'myalias@npm:@npmcli/test@1.2.3'],
   ]
   for (const [allowType, spec] of allowTypes) {
     t.test(`${allowType}: ${spec}`, t => {


### PR DESCRIPTION
This adds the last option needed to aggregate these in npm itself.

Ref: https://github.com/npm/statusboard/issues/1064