### PR TITLE
fix: prevent path duplication in attestation URL for registries with …

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -229,7 +229,7 @@ class RegistryFetcher extends Fetcher {
         if (this.opts.verifyAttestations) {
           // Always fetch attestations from the current registry host
           const attestationsPath = new URL(dist.attestations.url).pathname
-          const attestationsUrl = removeTrailingSlashes(this.registry) + attestationsPath
+          const attestationsUrl = new URL(attestationsPath, this.registry).href
           const res = await fetch(attestationsUrl, {
             ...this.opts,
             // disable integrity check for attestations json payload, we check the


### PR DESCRIPTION
<!-- What / Why -->
fix: prevent path duplication in attestation URL for registries with path components

<!-- Describe the request in detail. What it does and why it's being changed. -->
  When a custom registry URL includes a path (e.g. https://example.com/javascript),
  the attestation URL was incorrectly constructed by concatenating the full registry
  URL with the full pathname from the attestation URL, causing the path to be
  duplicated (e.g. /javascript/javascript/-/npm/v1/attestations/...).

  Use the URL constructor to correctly resolve the pathname against the registry
  origin, matching the existing pattern in lib/remote.js.

## References
  Fixes #450 
