### PR TITLE
fix: skip registry key check for keyless (Sigstore/Fulcio) attestations

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -256,7 +256,10 @@ class RegistryFetcher extends Fetcher {
           const attestationKeyIds = bundles.map((b) => b.keyid).filter((k) => !!k)
           const attestationRegistryKeys = (this.registryKeys || [])
             .filter(key => attestationKeyIds.includes(key.keyid))
-          if (!attestationRegistryKeys.length) {
+          // Only require registry keys when there are keyed attestations.
+          // Keyless (Sigstore/Fulcio) attestations embed their signing
+          // certificate in the bundle and don't need registry keys.
+          if (attestationKeyIds.length > 0 && !attestationRegistryKeys.length) {
             throw Object.assign(new Error(
               `${mani._id} has attestations but no corresponding public key(s) can be found`
             ), { code: 'EMISSINGSIGNATUREKEY' })


### PR DESCRIPTION
  fix: skip registry key check for keyless (Sigstore/Fulcio) attestations
  
  Attestations signed with keyless Sigstore/Fulcio have no keyid and
  embed the signing certificate directly in the bundle. The existing
  guard unconditionally required matching registry keys, causing
  EMISSINGSIGNATUREKEY for registries that only use keyless signing.

  Only throw when there are keyed attestations that can't be matched.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
