### PR TITLE
fix: fall back to git clone when tarball response is not a valid archive

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -254,8 +254,10 @@ class GitFetcher extends Fetcher {
           resolved: this.resolved,
           integrity: null, // it'll always be different, if we have one
         }).extract(tmp).then(() => handler(`${tmp}${this.spec.gitSubdir || ''}`), er => {
-          // fall back to ssh download if tarball fails
-          if (er.constructor.name.match(/^Http/)) {
+          // fall back to clone if the tarball download fails due to an
+          // HTTP error or if the response is not a valid tarball (e.g.
+          // a hosted provider returning an HTML sign-in page with 200)
+          if (er.constructor.name.match(/^Http/) || /^TAR_/.test(er.code)) {
             return this.#clone(handler, false)
           } else {
             throw er

--- a/test/git.js
+++ b/test/git.js
@@ -632,13 +632,31 @@ t.test('fetch a private repo where the tgz is a 404', { skip: isWindows && 'posi
 })
 
 t.test('fetch a private repo where the tgz is not a tarball', { skip: isWindows && 'posix only' },
-  t => {
+  () => {
     const gf = new GitFetcher(`localhost:repo/x#${REPO_HEAD}`, opts)
     gf.spec.hosted.tarball = () => `${hostedUrl}/not-tar.tgz`
-    // should NOT retry, because the error was not an HTTP fetch error
-    return t.rejects(gf.extract(me + '/bad-tgz'), {
-      code: 'TAR_BAD_ARCHIVE',
+    // should fall back to clone, since the tarball content is not valid.
+    // this can happen when a hosted git provider returns an HTML page
+    // (e.g. a sign-in page) with HTTP 200 for private repo archives.
+    return gf.extract(me + '/bad-tgz')
+  })
+
+t.test('non-retriable tarball error is thrown, not retried', { skip: isWindows && 'posix only' },
+  async t => {
+    const gf = new GitFetcher(`localhost:repo/x#${REPO_HEAD}`, opts)
+    gf.spec.hosted.tarball = () => `${hostedUrl}/not-tar.tgz`
+    // override the hosted tarball to simulate a non-recoverable error
+    // that is neither an HTTP error nor a TAR error
+    const orig = gf.spec.hosted.tarball
+    gf.spec.hosted.tarball = () => orig()
+    const RemoteFetcher = require('../lib/remote.js')
+    const _extract = RemoteFetcher.prototype.extract
+    t.teardown(() => {
+      RemoteFetcher.prototype.extract = _extract
     })
+    RemoteFetcher.prototype.extract = () =>
+      Promise.reject(Object.assign(new Error('bad'), { code: 'EINTEGRITY' }))
+    await t.rejects(gf.extract(me + '/bad-tgz-other'), { code: 'EINTEGRITY' })
   })
 
 t.test('resolved is a git+ssh url for hosted repos that support it',


### PR DESCRIPTION
## Summary

When a hosted git provider (e.g. GitLab) returns an HTML page with HTTP 200 for a private repo's archive endpoint instead of a proper 401/403, the tarball extraction fails with `TAR_BAD_ARCHIVE`. Previously, the fallback to git clone only triggered on HTTP errors (`er.constructor.name.match(/^Http/)`).

This widens the catch to also include TAR errors (`/^TAR_/.test(er.code)`), allowing pacote to recover by cloning the repo directly instead of throwing.

## What changed

- `lib/git.js`: Added `|| /^TAR_/.test(er.code)` to the error check in the `#clone` method's tarball fallback logic
- `test/git.js`: Updated "fetch a private repo where the tgz is not a tarball" test to expect successful fallback to clone instead of rejection; added test to verify non-recoverable errors (e.g. `EINTEGRITY`) still throw

## Why

GitLab (and potentially other hosted git providers) can return HTTP 200 with an HTML sign-in page for unauthenticated tarball requests on private repos, instead of a proper 401/403. npm's HTTP client follows the 302 redirect and sees a 200, so it treats the download as successful. The tar extractor then fails trying to parse HTML as a tarball.

This has been a known issue since 2021 (npm/cli#3229, npm/cli#2741) and recently started affecting more users due to a change in GitLab's redirect behavior for private repo archive endpoints.

Fixes #476
Ref: npm/cli#3229, npm/cli#2741