### PR TITLE
fix: use statusCode instead of constructor name for tarball fallback

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -255,7 +255,7 @@ class GitFetcher extends Fetcher {
           integrity: null, // it'll always be different, if we have one
         }).extract(tmp).then(() => handler(`${tmp}${this.spec.gitSubdir || ''}`), er => {
           // fall back to ssh download if tarball fails
-          if (er.constructor.name.match(/^Http/)) {
+          if (typeof er.statusCode === 'number' && er.statusCode >= 400) {
             return this.#clone(handler, false)
           } else {
             throw er

--- a/test/git.js
+++ b/test/git.js
@@ -15,6 +15,7 @@ const rimraf = require('rimraf')
 const tar = require('tar')
 const spawnNpm = require('../lib/util/npm.js')
 const GitFetcher = require('../lib/git.js')
+const RemoteFetcher = require('../lib/remote.js')
 
 // set this up first, so we can use 127.0.0.1 as our "hosted git" service
 const httpPort = 18000 + (+process.env.TAP_CHILD_ID || 0)
@@ -630,6 +631,22 @@ t.test('fetch a private repo where the tgz is a 404', { skip: isWindows && 'posi
   // should fetch it by falling back to ssh when it gets an http error
   return gf.extract(me + '/no-tgz')
 })
+
+t.test('fetch a private repo where the tgz is a 404 and http error has minified class name',
+  { skip: isWindows && 'posix only' }, async t => {
+    const gf = new GitFetcher(`localhost:repo/x#${REPO_HEAD}`, opts)
+    const origExtract = RemoteFetcher.prototype.extract
+    RemoteFetcher.prototype.extract = () => {
+      const err = new Error('404 Not Found')
+      err.statusCode = 404
+      err.code = 'E404'
+      return Promise.reject(err)
+    }
+    t.teardown(() => {
+      RemoteFetcher.prototype.extract = origExtract
+    })
+    await gf.extract(me + '/no-tgz')
+  })
 
 t.test('fetch a private repo where the tgz is not a tarball', { skip: isWindows && 'posix only' },
   t => {


### PR DESCRIPTION
The tarball-to-clone fallback in `GitFetcher.#clone()` uses `er.constructor.name.match(/^Http/)` to detect HTTP errors from `npm-registry-fetch`. This breaks when pacote is consumed by bundlers that minify identifiers (e.g. Bun's `Bun.build()` with `minify: true`, esbuild with `minifyIdentifiers`), because `HttpErrorGeneral` gets renamed to something like `jB` and the regex no longer matches.

When this happens, the fallback to SSH git clone never fires, and private hosted git repos (GitLab, GitHub) fail with a 403 or 404 from the tarball download with no recovery.