### PR TITLE
feat: forward globalIgnoreFile option to npm-packlist

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -66,7 +66,7 @@ class DirFetcher extends Fetcher {
     stream.resolved = this.resolved
     stream.integrity = this.integrity
 
-    const { prefix, workspaces } = this.opts
+    const { prefix, workspaces, globalIgnoreFile } = this.opts
 
     // run the prepare script, get the list of files, and tar it up
     // pipe to the stream, and proxy errors the chain.
@@ -76,7 +76,7 @@ class DirFetcher extends Fetcher {
           const arb = new this.Arborist({ path: this.resolved })
           this.tree = await arb.loadActual()
         }
-        return packlist(this.tree, { path: this.resolved, prefix, workspaces })
+        return packlist(this.tree, { path: this.resolved, prefix, workspaces, globalIgnoreFile })
       })
       .then(files => tar.c(tarCreateOptions(this.package), files)
         .on('error', er => stream.emit('error', er)).pipe(stream))

--- a/test/dir-global-ignore-file.js
+++ b/test/dir-global-ignore-file.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const t = require('tap')
+const { join } = require('node:path')
+const Arborist = require('@npmcli/arborist')
+
+// Verify that DirFetcher pulls `globalIgnoreFile` out of opts and passes it on
+// to npm-packlist. Use a mocked packlist so the assertion holds regardless of
+// whether the installed npm-packlist understands the option yet.
+t.test('DirFetcher forwards globalIgnoreFile to npm-packlist', async t => {
+  const dir = t.testdir({
+    pkg: {
+      'package.json': JSON.stringify({ name: 'pacote-fwd', version: '1.0.0' }, null, 2),
+      'index.js': '"use strict"\n',
+    },
+  })
+  const pkgDir = join(dir, 'pkg')
+
+  let receivedOpts = null
+  const pacote = t.mock('../lib/index.js', {
+    'npm-packlist': (tree, opts) => {
+      receivedOpts = opts
+      // return a minimal file list so tar.c can build a tarball
+      return Promise.resolve(['package.json', 'index.js'])
+    },
+  })
+
+  await pacote.tarball(`file:${pkgDir}`, {
+    Arborist,
+    globalIgnoreFile: '/some/path/to/.npmignore',
+  })
+
+  t.ok(receivedOpts, 'packlist was called')
+  t.equal(
+    receivedOpts.globalIgnoreFile,
+    '/some/path/to/.npmignore',
+    'globalIgnoreFile reached packlist'
+  )
+})
+
+t.test('DirFetcher does not pass globalIgnoreFile when caller omits it', async t => {
+  const dir = t.testdir({
+    pkg: {
+      'package.json': JSON.stringify({ name: 'pacote-no-fwd', version: '1.0.0' }, null, 2),
+      'index.js': '"use strict"\n',
+    },
+  })
+  const pkgDir = join(dir, 'pkg')
+
+  let receivedOpts = null
+  const pacote = t.mock('../lib/index.js', {
+    'npm-packlist': (tree, opts) => {
+      receivedOpts = opts
+      return Promise.resolve(['package.json', 'index.js'])
+    },
+  })
+
+  await pacote.tarball(`file:${pkgDir}`, { Arborist })
+
+  t.ok(receivedOpts, 'packlist was called')
+  t.equal(receivedOpts.globalIgnoreFile, undefined, 'undefined passed through')
+})


### PR DESCRIPTION
`DirFetcher` is the entry point for packing a directory spec and calls `npm-packlist` directly. Pull `globalIgnoreFile` off the opts and pass it through to packlist so a user level ignore file (configured by callers such as the npm cli) actually reaches the walker that decides which files end up in the tarball.

Includes a test that mocks `npm-packlist` to confirm the option is forwarded, and a complementary test confirming that omitting the option passes `undefined` through. The behavior on the packlist side lands in a separate npm-packlist release; this commit only adds the plumbing on the pacote side.

Required for https://github.com/npm/cli/pull/9351