### PR TITLE
feat: strip patchedDependencies from the packed package.json

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -1,8 +1,11 @@
-const { resolve } = require('node:path')
+const { resolve, join } = require('node:path')
+const { mkdtemp, writeFile, rm } = require('node:fs/promises')
+const { tmpdir } = require('node:os')
 const packlist = require('npm-packlist')
 const runScript = require('@npmcli/run-script')
 const tar = require('tar')
 const { Minipass } = require('minipass')
+const PackageJson = require('@npmcli/package-json')
 const Fetcher = require('./fetcher.js')
 const FileFetcher = require('./file.js')
 const _ = require('./util/protected.js')
@@ -78,10 +81,62 @@ class DirFetcher extends Fetcher {
         }
         return packlist(this.tree, { path: this.resolved, prefix, workspaces, globalIgnoreFile })
       })
-      .then(files => tar.c(tarCreateOptions(this.package), files)
-        .on('error', er => stream.emit('error', er)).pipe(stream))
+      .then(async files => {
+        const { options, cleanup } = await this.#tarOptions()
+        const source = tar.c(options, files)
+        // the strip temp file must outlive content consumption, so clean up once the stream is done
+        source.once('end', cleanup)
+        source.once('error', cleanup)
+        return source.on('error', er => stream.emit('error', er)).pipe(stream)
+      })
       .catch(er => stream.emit('error', er))
     return stream
+  }
+
+  // Build the tar create options.
+  // When the packed package.json declares patchedDependencies, redirect it to a stripped copy so project-local patches never ship.
+  // Non-patched packs are unchanged.
+  async #tarOptions () {
+    const options = tarCreateOptions(this.package)
+
+    // read package.json from disk after prepare so the strip reflects the actually-packed manifest.
+    const pkgJson = await PackageJson.load(this.resolved)
+    if (!('patchedDependencies' in pkgJson.content)) {
+      return { options, cleanup: () => {} }
+    }
+
+    // serialize the package.json minus patchedDependencies, preserving its indent and newline.
+    // JSON.stringify ignores the indent and newline symbols @npmcli/package-json attaches to content.
+    delete pkgJson.content.patchedDependencies
+    const { content } = pkgJson
+    const indent = content[Symbol.for('indent')]
+    const newline = content[Symbol.for('newline')]
+    const stripped = `${JSON.stringify(content, null, indent)}\n`.replace(/\n/g, newline)
+
+    // write the stripped copy to a temp dir, removing it if the write itself fails.
+    const dir = await mkdtemp(join(tmpdir(), 'pacote-pack-'))
+    const strippedPath = join(dir, 'package.json')
+    try {
+      await writeFile(strippedPath, stripped)
+    } catch (er) {
+      /* istanbul ignore next - writing to a freshly created temp dir is not deterministically failable */
+      await rm(dir, { recursive: true, force: true })
+      /* istanbul ignore next */
+      throw er
+    }
+    const size = Buffer.byteLength(stripped)
+
+    // point only the top-level package.json entry at the stripped copy; every other file is untouched.
+    // onWriteEntry runs before the tar header and the file's hardlink check, so size and nlink here are honored.
+    options.onWriteEntry = (entry) => {
+      if (entry.path === 'package.json') {
+        entry.absolute = strippedPath
+        entry.stat.size = size
+        entry.stat.nlink = 1
+      }
+    }
+
+    return { options, cleanup: () => rm(dir, { recursive: true, force: true }) }
   }
 
   manifest () {

--- a/test/dir-patched-dependencies.js
+++ b/test/dir-patched-dependencies.js
@@ -1,0 +1,59 @@
+const t = require('tap')
+const Arborist = require('@npmcli/arborist')
+const fs = require('node:fs')
+const { resolve } = require('node:path')
+const DirFetcher = require('../lib/dir.js')
+
+const loadActual = (path) => new Arborist({ path }).loadActual()
+const me = t.testdir()
+
+t.test('strips patchedDependencies from the packed package.json, preserving formatting', async t => {
+  const original = JSON.stringify({
+    name: 'patched-pkg',
+    version: '1.0.0',
+    main: 'index.js',
+    patchedDependencies: { 'abbrev@2.0.0': 'patches/abbrev@2.0.0.patch' },
+    license: 'MIT',
+  }, null, 2) + '\n'
+  const dir = t.testdir({
+    'package.json': original,
+    'index.js': 'module.exports = 1\n',
+    patches: { 'abbrev@2.0.0.patch': 'the patch\n' },
+  })
+  const f = new DirFetcher(`file:${dir}`, { tree: await loadActual(dir) })
+  const out = resolve(me, 'patched')
+  await f.extract(out)
+
+  const packed = fs.readFileSync(resolve(out, 'package.json'), 'utf8')
+  t.notMatch(packed, /patchedDependencies/, 'patchedDependencies stripped from the tarball')
+  const expected = JSON.stringify({
+    name: 'patched-pkg', version: '1.0.0', main: 'index.js', license: 'MIT',
+  }, null, 2) + '\n'
+  t.equal(packed, expected, 'other fields and the 2-space formatting are preserved')
+  // the source package.json on disk is never mutated
+  t.equal(fs.readFileSync(resolve(dir, 'package.json'), 'utf8'), original, 'source package.json untouched')
+})
+
+t.test('leaves a package without patchedDependencies byte-identical', async t => {
+  const original = '{\n  "name": "plain",\n  "version": "1.0.0",\n  "main": "index.js"\n}\n'
+  const dir = t.testdir({ 'package.json': original, 'index.js': 'x\n' })
+  const f = new DirFetcher(`file:${dir}`, { tree: await loadActual(dir) })
+  const out = resolve(me, 'plain')
+  await f.extract(out)
+  t.equal(fs.readFileSync(resolve(out, 'package.json'), 'utf8'), original, 'unchanged when no patches are declared')
+})
+
+t.test('falls back to default formatting for a minified package.json', async t => {
+  const dir = t.testdir({
+    'package.json':
+      '{"name":"min","version":"1.0.0","patchedDependencies":{"abbrev@2.0.0":"patches/a.patch"}}',
+    'index.js': 'x\n',
+    patches: { 'a.patch': 'p\n' },
+  })
+  const f = new DirFetcher(`file:${dir}`, { tree: await loadActual(dir) })
+  const out = resolve(me, 'min')
+  await f.extract(out)
+  const packed = fs.readFileSync(resolve(out, 'package.json'), 'utf8')
+  t.notMatch(packed, /patchedDependencies/, 'patchedDependencies stripped from a minified manifest')
+  t.match(packed, /"name":\s*"min"/, 'the rest of the manifest still ships')
+})


### PR DESCRIPTION
Part of native dependency patching ([npm/rfcs#862](https://github.com/npm/rfcs/pull/862)). When packing a `directory` spec (the `npm publish` / `npm pack` path), this strips a top-level `patchedDependencies` field from the `package.json` written **into the tarball**.

## Why

`patchedDependencies` declares project-local patches against installed dependencies. It is honored only in a root manifest, so it is meaningless to consumers of a published package and should never travel through the registry. The published *packument* manifest is already stripped in `libnpmpublish`; this closes the other half — the `package.json` inside the tarball itself — so `npm pack --dry-run` and the published tarball no longer carry the field. It pairs with the npm-packlist change that excludes the patch files themselves; together they guarantee a patched project publishes clean.

## How

`DirFetcher` packs the raw on-disk files via `tar.c`, so the tarball's `package.json` is the literal file on disk — there is no manifest seam to edit. The new `#tarOptions()`:

1. Reads the on-disk `package.json` (after `prepare`) via `@npmcli/package-json`. If it has no `patchedDependencies`, returns the existing options unchanged — **non-patched packs are byte-for-byte identical to before**.
2. Otherwise deletes the field and re-serializes preserving the original indent, newline, and key order (the indent/newline symbols `@npmcli/package-json` attaches; `JSON.stringify` ignores them), writes the stripped copy to a temp dir, and removes the temp dir if the write fails.
3. Sets node-tar's `onWriteEntry` to redirect **only** the top-level `package.json` entry's `absolute` at the stripped copy and fix its `stat.size`/`nlink`. `onWriteEntry` runs before the header and the file's hardlink check, so the override is honored; every other file is untouched.
4. The temp dir is removed once the tar source stream emits `end`/`error`, so it outlives content consumption.

No behavior change for any package without `patchedDependencies`.

## References

Part of
- https://github.com/npm/rfcs/pull/862

Related to
- https://github.com/npm/cli/pull/9439
- https://github.com/npm/npm-packlist/pull/291
