### PR TITLE
fix: avoid conflicting prefer config flags

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -104,8 +104,8 @@ class FetcherBase {
     // a dist-tag, but certainly wants to keep defaulting to latest.
     this.npmCliConfig = opts.npmCliConfig || [
       `--cache=${dirname(this.cache)}`,
-      `--prefer-offline=${!!this.preferOffline}`,
-      `--prefer-online=${!!this.preferOnline}`,
+      ...(this.preferOffline ? ['--prefer-offline=true'] : []),
+      ...(this.preferOnline ? ['--prefer-online=true'] : []),
       `--offline=${!!this.offline}`,
       ...(this.before ? [`--before=${this.before.toISOString()}`] : []),
       '--no-progress',

--- a/tap-snapshots/test/fetcher.js.test.cjs
+++ b/tap-snapshots/test/fetcher.js.test.cjs
@@ -37,8 +37,6 @@ Array [
 exports[`test/fetcher.js TAP snapshot the npmInstallCmd and npmInstallConfig > default install config 1`] = `
 Array [
   "--cache={CACHE}",
-  "--prefer-offline=false",
-  "--prefer-online=false",
   "--offline=false",
   "--no-progress",
   "--no-save",
@@ -55,8 +53,6 @@ Array [
 exports[`test/fetcher.js TAP snapshot the npmInstallCmd and npmInstallConfig > default install config with before 1`] = `
 Array [
   "--cache={CACHE}",
-  "--prefer-offline=false",
-  "--prefer-online=false",
   "--offline=false",
   "--before=1979-07-01T19:10:00.000Z",
   "--no-progress",

--- a/test/fetcher.js
+++ b/test/fetcher.js
@@ -69,6 +69,14 @@ t.test('snapshot the npmInstallCmd and npmInstallConfig', async t => {
     'do not have a _cacache folder on cache config passed to npm cli')
   t.equal(basename(def.cache), '_cacache',
     'have a _cacache folder on default pacote config itself')
+  t.not(def.npmCliConfig.includes('--prefer-offline=false'), 'does not pass disabled prefer-offline')
+  t.not(def.npmCliConfig.includes('--prefer-online=false'), 'does not pass disabled prefer-online')
+  const preferOffline = new FileFetcher(abbrevspec, { preferOffline: true })
+  t.ok(preferOffline.npmCliConfig.includes('--prefer-offline=true'), 'passes prefer-offline when enabled')
+  t.not(preferOffline.npmCliConfig.includes('--prefer-online=true'), 'does not pass prefer-online with prefer-offline')
+  const preferOnline = new FileFetcher(abbrevspec, { preferOnline: true })
+  t.ok(preferOnline.npmCliConfig.includes('--prefer-online=true'), 'passes prefer-online when enabled')
+  t.not(preferOnline.npmCliConfig.includes('--prefer-offline=true'), 'does not pass prefer-offline with prefer-online')
   const bef = new FileFetcher(abbrevspec, {
     before: new Date('1979-07-01T19:10:00.000Z'),
   })


### PR DESCRIPTION
Fixes #472.

`FetcherBase` currently always forwards both `--prefer-offline=false` and `--prefer-online=false` to the inner npm install command used while preparing git dependencies. Newer npm treats these configs as mutually exclusive, so setting both keys, even to false, can trip the stricter validation.

This changes the generated npm CLI config so the prefer flags are only forwarded when they are enabled:

- `preferOffline: true` adds `--prefer-offline=true`
- `preferOnline: true` adds `--prefer-online=true`
- the default path omits both prefer flags

The existing snapshot for the default config was updated, and the fetcher test now asserts the enabled/disabled cases explicitly.

Verification:

- `npx tap test/fetcher.js`
  - Relevant assertions passed.
  - The command still exits non-zero when run as a single file because the repo's global coverage threshold expects the full suite.
- `npm run eslint -- lib/fetcher.js test/fetcher.js`
- `git diff --check`

I also ran `npm test`; it progressed through the relevant `test/fetcher.js` suite successfully, then stopped later in `test/git.js` during local fixture setup with `ENOENT` for `test/tap-testdir-git/submodule-repo/package.json`, which appears unrelated to this change.
